### PR TITLE
docs: Add `fetch` example (+ chore)

### DIFF
--- a/examples/fetch.rs
+++ b/examples/fetch.rs
@@ -1,0 +1,54 @@
+use imap_client::{
+    imap_types::{
+        fetch::{Macro, MacroOrMessageDataItemNames, MessageDataItem},
+        sequence::SequenceSet,
+    },
+    Client,
+};
+
+const USAGE: &str =
+    "USAGE: cargo run --example=fetch -- <host> <port> <username> <password>";
+
+#[tokio::main]
+async fn main() {
+    let (host, port, username, password) = {
+        let mut args = std::env::args();
+        let _ = args.next();
+
+        (
+            args.next().expect(USAGE),
+            str::parse::<u16>(&args.next().expect(USAGE)).unwrap(),
+            args.next().expect(USAGE),
+            args.next().expect(USAGE),
+        )
+    };
+
+    let mut client = Client::tls(host, port).await.unwrap();
+
+    client.authenticate_plain(username, password).await.unwrap();
+
+    let select_data = client.select("inbox").await.unwrap();
+    println!("{select_data:?}\n");
+
+    let data = client
+        .fetch(
+            SequenceSet::try_from("1:10").unwrap(),
+            MacroOrMessageDataItemNames::Macro(Macro::Full),
+        )
+        .await
+        .unwrap();
+
+    println!("# INBOX\n");
+    for (_, items) in data {
+        let envelope = items
+            .as_ref()
+            .iter()
+            .find(|item| matches!(item, MessageDataItem::Envelope(_)))
+            .unwrap();
+        if let MessageDataItem::Envelope(env) = envelope {
+            if let Some(sub) = &env.subject.0 {
+                println!("* {:?}", std::str::from_utf8(sub.as_ref()).unwrap());
+            }
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ pub mod tasks;
 
 use std::{cmp::Ordering, collections::HashMap, num::NonZeroU32, sync::Arc, time::Duration};
 
+pub use imap_next::imap_types;
 use imap_next::{
     client::{Client as ClientNext, Error as NextError, Event, Options},
     imap_types::{


### PR DESCRIPTION
A simple example (that can reproduce the `imap.transip.email` timeout).