### PR TITLE
feat(smol): Add support for the smol runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 
 # IntelliJ, CLion, RustRover, ...
 .idea
+# VS Code
+.vscode
 
 # direnv (https://direnv.net/)
 .envrc

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,18 +13,18 @@ dependencies = [
 
 [[package]]
 name = "addr2line"
-version = "0.24.2"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
 dependencies = [
  "gimli",
 ]
 
 [[package]]
 name = "adler2"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "async-attributes"
@@ -49,9 +49,9 @@ dependencies = [
 
 [[package]]
 name = "async-channel"
-version = "2.3.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
 dependencies = [
  "concurrent-queue",
  "event-listener-strategy",
@@ -61,14 +61,15 @@ dependencies = [
 
 [[package]]
 name = "async-executor"
-version = "1.13.1"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30ca9a001c1e8ba5149f91a74362376cc6bc5b919d92d988668657bd570bdcec"
+checksum = "497c00e0fd83a72a79a39fcbd8e3e2f055d6f6c7e025f3b3d91f4f8e76527fb8"
 dependencies = [
  "async-task",
  "concurrent-queue",
  "fastrand",
  "futures-lite",
+ "pin-project-lite",
  "slab",
 ]
 
@@ -78,7 +79,7 @@ version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
 dependencies = [
- "async-channel 2.3.1",
+ "async-channel 2.5.0",
  "async-executor",
  "async-io",
  "async-lock",
@@ -89,11 +90,11 @@ dependencies = [
 
 [[package]]
 name = "async-io"
-version = "2.4.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a2b323ccce0a1d90b449fd71f2a06ca7faa7c54c2751f06c9bd851fc061059"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
 dependencies = [
- "async-lock",
+ "autocfg",
  "cfg-if",
  "concurrent-queue",
  "futures-io",
@@ -102,26 +103,25 @@ dependencies = [
  "polling",
  "rustix",
  "slab",
- "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
 name = "async-lock"
-version = "3.4.0"
+version = "3.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff6e472cdea888a4bd64f342f09b3f50e1886d32afe8df3d663c01140b811b18"
+checksum = "5fd03604047cee9b6ce9de9f70c6cd540a0520c813cbd49bae61f33ab80ed1dc"
 dependencies = [
- "event-listener 5.4.0",
+ "event-listener 5.4.1",
  "event-listener-strategy",
  "pin-project-lite",
 ]
 
 [[package]]
 name = "async-std"
-version = "1.13.0"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c634475f29802fde2b8f0b505b1bd00dfe4df7d4a000f0b36f7671197d5c3615"
+checksum = "2c8e079a4ab67ae52b7403632e4618815d6db36d2a010cfe41b02c1b1578f93b"
 dependencies = [
  "async-attributes",
  "async-channel 1.9.0",
@@ -158,15 +158,15 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "backtrace"
-version = "0.3.74"
+version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
 dependencies = [
  "addr2line",
  "cfg-if",
@@ -174,7 +174,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-targets",
+ "windows-link",
 ]
 
 [[package]]
@@ -185,17 +185,17 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
-version = "2.7.0"
+version = "2.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1be3f42a67d6d345ecd59f675f3f012d6974981560836e938c22b424b85ce1be"
+checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
 
 [[package]]
 name = "blocking"
-version = "1.6.1"
+version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703f41c54fc768e63e091340b424302bb1c29ef4aa0c7f10fe849dfb114d29ea"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
 dependencies = [
- "async-channel 2.3.1",
+ "async-channel 2.5.0",
  "async-task",
  "futures-io",
  "futures-lite",
@@ -216,33 +216,28 @@ checksum = "e0af050e27e5d57aa14975f97fe47a134c46a390f91819f23a625319a7111bfa"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "bumpalo"
-version = "3.16.0"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
-
-[[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "bytes"
-version = "1.9.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cc"
-version = "1.2.8"
+version = "1.2.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad0cf6e91fde44c773c6ee7ec6bba798504641a8bc2eb7e37a04ffbf4dfaa55a"
+checksum = "e1354349954c6fc9cb0deab020f27f783cf0b604e8bb754dc4658ecf0d29c35f"
 dependencies = [
+ "find-msvc-tools",
  "shlex",
 ]
 
@@ -254,15 +249,15 @@ checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
 
 [[package]]
 name = "chrono"
-version = "0.4.39"
+version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
+checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
 dependencies = [
  "num-traits",
 ]
@@ -297,6 +292,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -310,12 +315,12 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "errno"
-version = "0.3.10"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -326,9 +331,9 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "event-listener"
-version = "5.4.0"
+version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3492acde4c3fc54c845eaab3eed8bd00c7a7d881f78bfc801e43a93dec1331ae"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
 dependencies = [
  "concurrent-queue",
  "parking",
@@ -337,11 +342,11 @@ dependencies = [
 
 [[package]]
 name = "event-listener-strategy"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c3e4e0dd3673c1139bf041f3008816d9cf2946bbfac2945c09e523b8d7b05b2"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
- "event-listener 5.4.0",
+ "event-listener 5.4.1",
  "pin-project-lite",
 ]
 
@@ -350,6 +355,12 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ced73b1dacfc750a6db6c0a0c3a3853c8b41997e2e2c563dc90804ae6867959"
 
 [[package]]
 name = "foreign-types"
@@ -389,9 +400,9 @@ checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-lite"
-version = "2.5.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cef40d21ae2c515b51041df9ed313ed21e572df340ea58a922a0aefe7e8891a1"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
 dependencies = [
  "fastrand",
  "futures-core",
@@ -402,20 +413,32 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi 0.14.7+wasi-0.2.4",
 ]
 
 [[package]]
 name = "gimli"
-version = "0.31.1"
+version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "gloo-timers"
@@ -431,9 +454,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.4.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "imap-client"
@@ -445,7 +468,7 @@ dependencies = [
  "rip-starttls",
  "rustls-platform-verifier",
  "static_assertions",
- "thiserror 2.0.11",
+ "thiserror 2.0.16",
  "tokio",
  "tokio-native-tls",
  "tokio-rustls",
@@ -474,7 +497,7 @@ checksum = "56d85520e742d9e8d9edbf9df9e0876f560ed08650db8f9de562bc7cd46b9b43"
 dependencies = [
  "bytes",
  "imap-codec",
- "thiserror 2.0.11",
+ "thiserror 2.0.16",
  "tokio",
  "tokio-rustls",
  "tracing",
@@ -495,17 +518,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "jni"
-version = "0.19.0"
+name = "io-uring"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6df18c2e3db7e453d3c6ac5b3e9d5182664d28788126d39b91f2d1e22b017ec"
+checksum = "046fa2d4d00aea763528b4950358d0ead425372445dc8ff86312b3c69ff7727b"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
+name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
 dependencies = [
  "cesu8",
+ "cfg-if",
  "combine",
  "jni-sys",
  "log",
  "thiserror 1.0.69",
  "walkdir",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -516,9 +552,9 @@ checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
 name = "js-sys"
-version = "0.3.76"
+version = "0.3.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6717b6b5b077764fb5966237269cb3c64edddde4b14ce42647430a78ced9e7b7"
+checksum = "ec48937a97411dcb524a265206ccd4c90bb711fca92b2792c407f268825b9305"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -535,21 +571,21 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.169"
+version = "0.2.176"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+checksum = "58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.15"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "lock_api"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -557,18 +593,18 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.24"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6ea2a48c204030ee31a7d7fc72c93294c92fe87ecb1789881c9543516e1a0d"
+checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 dependencies = [
  "value-bag",
 ]
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "minimal-lexical"
@@ -578,29 +614,29 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.2"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ffbe83022cedc1d264172192511ae958937694cd57ce297164951b8b3568394"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
 ]
 
 [[package]]
 name = "mio"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
+checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
- "wasi",
- "windows-sys 0.52.0",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "native-tls"
-version = "0.2.12"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8614eb2c83d59d1c8cc974dd3f920198647674a0a035e1af1fa58707e317466"
+checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
 dependencies = [
  "libc",
  "log",
@@ -608,7 +644,7 @@ dependencies = [
  "openssl-probe",
  "openssl-sys",
  "schannel",
- "security-framework",
+ "security-framework 2.11.1",
  "security-framework-sys",
  "tempfile",
 ]
@@ -624,25 +660,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-bigint"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
-dependencies = [
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-integer"
-version = "0.1.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -653,24 +670,24 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.7"
+version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.20.2"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "openssl"
-version = "0.10.68"
+version = "0.10.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6174bc48f102d208783c2c84bf931bb75927a617866870de8a4ea85597f871f5"
+checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -689,29 +706,29 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-src"
-version = "300.4.1+3.4.0"
+version = "300.5.2+3.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faa4eac4138c62414b5622d1b31c5c304f34b406b013c079c2bbc652fdd6678c"
+checksum = "d270b79e2926f5150189d475bc7e9d2c69f9c4697b185fa917d5a32b792d21b4"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.104"
+version = "0.9.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45abf306cbf99debc8195b66b7346498d7b10c210de50418b5ccd7ceba08c741"
+checksum = "90096e2e47630d78b7d1c20952dc621f957103f8bc2c8359ec81290d75238571"
 dependencies = [
  "cc",
  "libc",
@@ -728,9 +745,9 @@ checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -738,15 +755,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -774,51 +791,56 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "polling"
-version = "3.7.4"
+version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a604568c3202727d1507653cb121dbd627a58684eb09a820fd746bee38b4442f"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
  "hermit-abi",
  "pin-project-lite",
  "rustix",
- "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.20"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.93"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
+checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.38"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
@@ -847,29 +869,28 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.16",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.8"
+version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
+checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "ring"
-version = "0.17.8"
+version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.16",
  "libc",
- "spin",
  "untrusted",
  "windows-sys 0.52.0",
 ]
@@ -886,28 +907,28 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.24"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
 
 [[package]]
 name = "rustix"
-version = "0.38.43"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a78891ee6bf2340288408954ac787aa063d8e8817e9f53abb37c695c6d834ef6"
+checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
 dependencies = [
  "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.21"
+version = "0.23.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f287924602bf649d949c63dc8ac8b235fa5387d394020705b80c4eb597ce5b8"
+checksum = "cd3c25631629d034ce7cd9940adc9d45762d46de2b0f57193c4443b92c6d4d40"
 dependencies = [
  "log",
  "once_cell",
@@ -920,39 +941,32 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.7.3"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
+checksum = "7fcff2dd52b58a8d98a70243663a0d234c4e2b79235637849d15913394a247d3"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile",
  "rustls-pki-types",
  "schannel",
- "security-framework",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
+ "security-framework 3.5.1",
 ]
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.10.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2bf47e6ff922db3825eb750c4e2ff784c6ff8fb9e13046ef6a1d1c5401b0b37"
+checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
+dependencies = [
+ "zeroize",
+]
 
 [[package]]
 name = "rustls-platform-verifier"
-version = "0.4.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4c7dc240fec5517e6c4eab3310438636cfe6391dfc345ba013109909a90d136"
+checksum = "be59af91596cac372a6942530653ad0c3a246cdd491aaa9dcaee47f88d67d5a0"
 dependencies = [
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "jni",
  "log",
@@ -961,10 +975,10 @@ dependencies = [
  "rustls-native-certs",
  "rustls-platform-verifier-android",
  "rustls-webpki",
- "security-framework",
+ "security-framework 3.5.1",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -975,14 +989,20 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.8"
+version = "0.103.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+checksum = "8572f3c2cb9934231157b45499fc41e1f58c589fdfb81a844ba873265e80f8eb"
 dependencies = [
  "ring",
  "rustls-pki-types",
  "untrusted",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "same-file"
@@ -995,11 +1015,11 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
+checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -1015,18 +1035,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
  "bitflags",
- "core-foundation",
+ "core-foundation 0.9.4",
  "core-foundation-sys",
  "libc",
- "num-bigint",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
  "security-framework-sys",
 ]
 
 [[package]]
 name = "security-framework-sys"
-version = "2.14.0"
+version = "2.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
+checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1040,43 +1072,34 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.2"
+version = "1.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
+checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "slab"
-version = "0.4.9"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
-dependencies = [
- "autocfg",
-]
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "smallvec"
-version = "1.13.2"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.5.8"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
+checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
-
-[[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "static_assertions"
@@ -1103,9 +1126,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.96"
+version = "2.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5d0adab1ae378d7f53bdebc67a39f1f151407ef230f0ce2883572f5d8985c80"
+checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1114,16 +1137,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.15.0"
+version = "3.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8a559c81686f576e8cd0290cd2a24a2a9ad80c98b3478856500fcbd7acd704"
+checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
 dependencies = [
- "cfg-if",
  "fastrand",
- "getrandom",
+ "getrandom 0.3.3",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -1137,11 +1159,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.11"
+version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
+checksum = "3467d614147380f2e4e374161426ff399c91084acd2363eaf549172b3d5e60c0"
 dependencies = [
- "thiserror-impl 2.0.11",
+ "thiserror-impl 2.0.16",
 ]
 
 [[package]]
@@ -1152,36 +1174,38 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.11"
+version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
+checksum = "6c5e1be1c48b9172ee610da68fd9cd2770e7a4056cb3fc98710ee6906f0c7960"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "tokio"
-version = "1.43.0"
+version = "1.47.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d61fa4ffa3de412bfea335c6ecff681de2b609ba3c77ef3e00e521813a9ed9e"
+checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
 dependencies = [
  "backtrace",
  "bytes",
+ "io-uring",
  "libc",
  "mio",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
+ "slab",
  "socket2",
  "tokio-macros",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1192,7 +1216,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1207,9 +1231,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.1"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6d0975eaace0cf0fcadee4e4aaa5da15b5c079146f2cffb67c113be122bf37"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
  "tokio",
@@ -1228,29 +1252,29 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.28"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
+checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.33"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
+checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
 ]
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.14"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
+checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
 
 [[package]]
 name = "untrusted"
@@ -1260,9 +1284,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "value-bag"
-version = "1.10.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ef4c4aa54d5d05a279399bfa921ec387b7aba77caf7a682ae8d86785b8fdad2"
+checksum = "943ce29a8a743eb10d6082545d861b24f9d1b160b7d741e0f2cdf726bec909c5"
 
 [[package]]
 name = "vcpkg"
@@ -1282,40 +1306,60 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
+version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasi"
+version = "0.14.7+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
+dependencies = [
+ "wasip2",
+]
+
+[[package]]
+name = "wasip2"
+version = "1.0.1+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.99"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a474f6281d1d70c17ae7aa6a613c87fce69a127e2624002df63dcb39d6cf6396"
+checksum = "c1da10c01ae9f1ae40cbfac0bac3b1e724b320abfcf52229f80b547c0d250e2d"
 dependencies = [
  "cfg-if",
  "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.99"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f89bb38646b4f81674e8f5c3fb81b562be1fd936d84320f3264486418519c79"
+checksum = "671c9a5a66f49d8a47345ab942e2cb93c7d1d0339065d4f8139c486121b43b19"
 dependencies = [
  "bumpalo",
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.106",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.49"
+version = "0.4.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38176d9b44ea84e9184eff0bc34cc167ed044f816accfe5922e54d84cf48eca2"
+checksum = "7e038d41e478cc73bae0ff9b36c60cff1c98b8f38f8d7e8061e79ee63608ac5c"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -1326,9 +1370,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.99"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cc6181fd9a7492eef6fef1f33961e3695e4579b9872a6f7c83aee556666d4fe"
+checksum = "7ca60477e4c59f5f2986c50191cd972e3a50d8a95603bc9434501cf156a9a119"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1336,28 +1380,31 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.99"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d7a95b763d3c45903ed6c81f156801839e5ee968bb07e534c44df0fcd330c2"
+checksum = "9f07d2f20d4da7b26400c9f4a0511e6e0345b040694e8a75bd41d578fa4421d7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.106",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.99"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "943aab3fdaaa029a6e0271b35ea10b72b943135afe9bffca82384098ad0e06a6"
+checksum = "bad67dc8b2a1a6e5448428adec4c3e84c43e561d8c9ee8a9e5aabeb193ec41d1"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "web-sys"
-version = "0.3.76"
+version = "0.3.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dd7223427d52553d3702c004d3b2fe07c148165faa56313cb00211e31c12bc"
+checksum = "9367c417a924a74cae129e6a2ae3b47fabb1f8995595ab474029da749a8be120"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1365,20 +1412,35 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "0.26.7"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cd5da49bdf1f30054cfe0b8ce2958b8fbeb67c4d82c8967a598af481bef255c"
+checksum = "4e4ffd8df1c57e87c325000a3d6ef93db75279dc3a231125aac571650f22b12a"
 dependencies = [
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "winapi-util"
-version = "0.1.9"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.1",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
 ]
 
 [[package]]
@@ -1387,7 +1449,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1396,7 +1458,31 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f109e41dd4a3c848907eb83d5a42ea98b3769495597450cf6d153507b166f0f"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -1405,15 +1491,21 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -1423,9 +1515,21 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1441,9 +1545,21 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1453,9 +1569,21 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -1464,24 +1592,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "zerocopy"
-version = "0.7.35"
+name = "wit-bindgen"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+
+[[package]]
+name = "zerocopy"
+version = "0.8.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
 dependencies = [
- "byteorder",
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.35"
+version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.106",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,24 +27,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
-name = "async-attributes"
-version = "1.1.2"
+name = "aho-corasick"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3203e79f4dd9bdda415ed03cf14dae5a2bf775c683a00f94e9cd1faf0f596e5"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "async-channel"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
-dependencies = [
- "concurrent-queue",
- "event-listener 2.5.3",
- "futures-core",
+ "memchr",
 ]
 
 [[package]]
@@ -74,18 +62,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-global-executor"
-version = "2.4.1"
+name = "async-fs"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
+checksum = "8034a681df4aed8b8edbd7fbe472401ecf009251c8b40556b304567052e294c5"
 dependencies = [
- "async-channel 2.5.0",
- "async-executor",
- "async-io",
  "async-lock",
  "blocking",
  "futures-lite",
- "once_cell",
 ]
 
 [[package]]
@@ -112,36 +96,68 @@ version = "3.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fd03604047cee9b6ce9de9f70c6cd540a0520c813cbd49bae61f33ab80ed1dc"
 dependencies = [
- "event-listener 5.4.1",
+ "event-listener",
  "event-listener-strategy",
  "pin-project-lite",
 ]
 
 [[package]]
-name = "async-std"
-version = "1.13.2"
+name = "async-native-tls"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c8e079a4ab67ae52b7403632e4618815d6db36d2a010cfe41b02c1b1578f93b"
+checksum = "9343dc5acf07e79ff82d0c37899f079db3534d99f189a1837c8e549c99405bec"
 dependencies = [
- "async-attributes",
- "async-channel 1.9.0",
- "async-global-executor",
+ "futures-util",
+ "native-tls",
+ "thiserror 1.0.69",
+ "url",
+]
+
+[[package]]
+name = "async-net"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b948000fad4873c1c9339d60f2623323a0cfd3816e5181033c6a5cb68b2accf7"
+dependencies = [
+ "async-io",
+ "blocking",
+ "futures-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel",
  "async-io",
  "async-lock",
- "crossbeam-utils",
- "futures-channel",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43c070bbf59cd3570b6b2dd54cd772527c7c3620fce8be898406dd3ed6adc64c"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
  "futures-core",
  "futures-io",
- "futures-lite",
- "gloo-timers",
- "kv-log-macro",
- "log",
- "memchr",
- "once_cell",
- "pin-project-lite",
- "pin-utils",
+ "rustix",
+ "signal-hook-registry",
  "slab",
- "wasm-bindgen-futures",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -161,6 +177,30 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879b6c89592deb404ba4dc0ae6b58ffd1795c78991cbb5b8bc441c48a070440d"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ba2e2516bdf37af57fc6ff047855f54abad0066e5c4fdaaeb76dabb2e05bcf5"
+dependencies = [
+ "bindgen",
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "libloading",
+]
 
 [[package]]
 name = "backtrace"
@@ -184,6 +224,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "itertools",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -195,7 +255,7 @@ version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
 dependencies = [
- "async-channel 2.5.0",
+ "async-channel",
  "async-task",
  "futures-io",
  "futures-lite",
@@ -216,14 +276,8 @@ checksum = "e0af050e27e5d57aa14975f97fe47a134c46a390f91819f23a625319a7111bfa"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn",
 ]
-
-[[package]]
-name = "bumpalo"
-version = "3.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "bytes"
@@ -238,6 +292,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1354349954c6fc9cb0deab020f27f783cf0b604e8bb754dc4658ecf0d29c35f"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -246,6 +302,15 @@ name = "cesu8"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
 
 [[package]]
 name = "cfg-if"
@@ -260,6 +325,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -314,6 +399,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -322,12 +430,6 @@ dependencies = [
  "libc",
  "windows-sys 0.61.1",
 ]
-
-[[package]]
-name = "event-listener"
-version = "2.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "event-listener"
@@ -346,7 +448,7 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
- "event-listener 5.4.1",
+ "event-listener",
  "pin-project-lite",
 ]
 
@@ -378,13 +480,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
-name = "futures-channel"
-version = "0.3.31"
+name = "form_urlencoded"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
- "futures-core",
+ "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures-core"
@@ -409,6 +517,50 @@ dependencies = [
  "futures-io",
  "parking",
  "pin-project-lite",
+]
+
+[[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-rustls"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f2f12607f92c69b12ed746fabf9ca4f5c482cba46679c1a75b874ed7c26adb"
+dependencies = [
+ "futures-io",
+ "rustls",
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "futures-task"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+
+[[package]]
+name = "futures-util"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+dependencies = [
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -441,16 +593,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
-name = "gloo-timers"
-version = "0.3.0"
+name = "glob"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
-dependencies = [
- "futures-channel",
- "futures-core",
- "js-sys",
- "wasm-bindgen",
-]
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "hermit-abi"
@@ -459,14 +605,122 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
+name = "icu_collections"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cde2700ccaed3872079a65fb1a78f6c0a36c91570f28755dda67bc8f7d9f00a"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "436880e8e18df4d7bbc06d58432329d6458cc84531f7ac5f024e93deadb37979"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
+
+[[package]]
+name = "icu_properties"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "016c619c1eeb94efb86809b015c58f479963de65bdb6253345c1a1276f22e32b"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "potential_utf",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
+
+[[package]]
+name = "icu_provider"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03c80da27b5f4187909049ee2d72f276f0d9f99a42c306bd0131ecfe04d8e5af"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "stable_deref_trait",
+ "tinystr",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
 name = "imap-client"
 version = "0.2.3"
 dependencies = [
- "async-std",
- "imap-client",
+ "async-native-tls",
+ "futures-rustls",
  "imap-next",
  "rip-starttls",
  "rustls-platform-verifier",
+ "smol",
  "static_assertions",
  "thiserror 2.0.16",
  "tokio",
@@ -529,6 +783,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "jni"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -551,22 +814,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
-name = "js-sys"
-version = "0.3.81"
+name = "jobserver"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec48937a97411dcb524a265206ccd4c90bb711fca92b2792c407f268825b9305"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
 dependencies = [
- "once_cell",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "kv-log-macro"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
-dependencies = [
- "log",
+ "getrandom 0.3.3",
+ "libc",
 ]
 
 [[package]]
@@ -576,10 +830,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174"
 
 [[package]]
+name = "libloading"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
+dependencies = [
+ "cfg-if",
+ "windows-targets 0.53.4",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+
+[[package]]
+name = "litemap"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
 name = "lock_api"
@@ -596,9 +866,6 @@ name = "log"
 version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
-dependencies = [
- "value-bag",
-]
 
 [[package]]
 name = "memchr"
@@ -706,7 +973,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn",
 ]
 
 [[package]]
@@ -767,6 +1034,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -810,12 +1083,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "potential_utf"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84df19adbe5b5a0782edcab45899906947ab039ccf4573713735ee7de1e6b08a"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
 ]
 
 [[package]]
@@ -882,6 +1174,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b5288124840bee7b386bc413c487869b360b2b4ec421ea56425128692f2a82c"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "833eb9ce86d40ef33cb1306d8accf7bc8ec2bfea4355cbdebb3df68b40925cad"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -898,9 +1219,10 @@ dependencies = [
 [[package]]
 name = "rip-starttls"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edf1f62c7965137bde00221c63e20e511bb4d576e2ddf9bdf57e1d03042ba112"
+source = "git+https://github.com/felinira/pimalaya-core?branch=wip/smol-deps#346b7d861db3c46e3d67dc09ca63308a1dd677e1"
 dependencies = [
+ "async-net",
+ "futures-lite",
  "tokio",
  "tracing",
 ]
@@ -910,6 +1232,12 @@ name = "rustc-demangle"
 version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustix"
@@ -930,6 +1258,7 @@ version = "0.23.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd3c25631629d034ce7cd9940adc9d45762d46de2b0f57193c4443b92c6d4d40"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -993,16 +1322,11 @@ version = "0.103.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8572f3c2cb9934231157b45499fc41e1f58c589fdfb81a844ba873265e80f8eb"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
 ]
-
-[[package]]
-name = "rustversion"
-version = "1.0.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "same-file"
@@ -1065,6 +1389,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1092,6 +1446,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "smol"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a33bd3e260892199c3ccfc487c88b2da2265080acb316cd920da72fdfd7c599f"
+dependencies = [
+ "async-channel",
+ "async-executor",
+ "async-fs",
+ "async-io",
+ "async-lock",
+ "async-net",
+ "async-process",
+ "blocking",
+ "futures-lite",
+]
+
+[[package]]
 name = "socket2"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1100,6 +1471,12 @@ dependencies = [
  "libc",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "static_assertions"
@@ -1115,17 +1492,6 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
-name = "syn"
 version = "2.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
@@ -1133,6 +1499,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1174,7 +1551,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn",
 ]
 
 [[package]]
@@ -1185,7 +1562,17 @@ checksum = "6c5e1be1c48b9172ee610da68fd9cd2770e7a4056cb3fc98710ee6906f0c7960"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
+dependencies = [
+ "displaydoc",
+ "zerovec",
 ]
 
 [[package]]
@@ -1216,7 +1603,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn",
 ]
 
 [[package]]
@@ -1258,7 +1645,7 @@ checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn",
 ]
 
 [[package]]
@@ -1283,10 +1670,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
-name = "value-bag"
-version = "1.11.1"
+name = "url"
+version = "2.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "943ce29a8a743eb10d6082545d861b24f9d1b160b7d741e0f2cdf726bec909c5"
+checksum = "08bc136a29a3d1758e07a9cca267be308aeebf5cfd5a10f3f67ab2097683ef5b"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "vcpkg"
@@ -1326,88 +1725,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
 dependencies = [
  "wit-bindgen",
-]
-
-[[package]]
-name = "wasm-bindgen"
-version = "0.2.104"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1da10c01ae9f1ae40cbfac0bac3b1e724b320abfcf52229f80b547c0d250e2d"
-dependencies = [
- "cfg-if",
- "once_cell",
- "rustversion",
- "wasm-bindgen-macro",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.104"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "671c9a5a66f49d8a47345ab942e2cb93c7d1d0339065d4f8139c486121b43b19"
-dependencies = [
- "bumpalo",
- "log",
- "proc-macro2",
- "quote",
- "syn 2.0.106",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-futures"
-version = "0.4.54"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e038d41e478cc73bae0ff9b36c60cff1c98b8f38f8d7e8061e79ee63608ac5c"
-dependencies = [
- "cfg-if",
- "js-sys",
- "once_cell",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
-name = "wasm-bindgen-macro"
-version = "0.2.104"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ca60477e4c59f5f2986c50191cd972e3a50d8a95603bc9434501cf156a9a119"
-dependencies = [
- "quote",
- "wasm-bindgen-macro-support",
-]
-
-[[package]]
-name = "wasm-bindgen-macro-support"
-version = "0.2.104"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f07d2f20d4da7b26400c9f4a0511e6e0345b040694e8a75bd41d578fa4421d7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.106",
- "wasm-bindgen-backend",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-shared"
-version = "0.2.104"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bad67dc8b2a1a6e5448428adec4c3e84c43e561d8c9ee8a9e5aabeb193ec41d1"
-dependencies = [
- "unicode-ident",
-]
-
-[[package]]
-name = "web-sys"
-version = "0.3.81"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9367c417a924a74cae129e6a2ae3b47fabb1f8995595ab474029da749a8be120"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1494,11 +1811,28 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d42b7b7f66d2a06854650af09cfdf8713e427a439c97ad65a6375318033ac4b"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -1514,6 +1848,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1524,6 +1864,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1538,10 +1884,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1556,6 +1914,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1566,6 +1930,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -1580,6 +1950,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1592,10 +1968,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+
+[[package]]
 name = "wit-bindgen"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+
+[[package]]
+name = "writeable"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
+
+[[package]]
+name = "yoke"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc"
+dependencies = [
+ "serde",
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
 
 [[package]]
 name = "zerocopy"
@@ -1614,7 +2026,28 @@ checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
 ]
 
 [[package]]
@@ -1622,3 +2055,36 @@ name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36f0bbd478583f79edad978b407914f61b2972f5af6fa089686016be8f9af595"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7aa2bd55086f1ab526693ecbe444205da57e25f4489879da80635a46d90e73b"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,24 +14,37 @@ repository = "https://github.com/pimalaya/imap-client/"
 [features]
 default = []
 
+# Executors
+tokio = ["dep:tokio", "rip-starttls/tokio"]
+smol = ["dep:smol", "rip-starttls/smol"]
+
 # TLS providers
-#
+# tokio
 tokio-rustls = [
+    "tokio",
     "dep:tokio-rustls",
-    "dep:rip-starttls",
     "dep:rustls-platform-verifier",
+    "rip-starttls/tokio",
 ]
-tokio-native-tls = ["dep:tokio-native-tls", "dep:rip-starttls"]
+tokio-native-tls = ["tokio", "dep:tokio-native-tls", "rip-starttls/tokio"]
 
 # Vendored (mostly for OpenSSL)
 #
 vendored = ["tokio-native-tls?/vendored"]
 
+# smol
+async-native-tls = ["smol", "rip-starttls/smol", "dep:async-native-tls"]
+futures-rustls = [
+    "smol",
+    "dep:rustls-platform-verifier",
+    "rip-starttls/smol",
+    "dep:futures-rustls",
+]
+
 [dev-dependencies]
-async-std = { version = "1.13", features = ["attributes"] }
-imap-client = { path = ".", features = ["tokio-rustls", "tokio-native-tls"] }
 static_assertions = "1.1"
 tokio = { version = "1.37", features = ["full"] }
+smol = { version = "2" }
 
 [dependencies]
 imap-next = { version = "0.3", features = [
@@ -39,10 +52,14 @@ imap-next = { version = "0.3", features = [
     "ext_id",
     "ext_metadata",
 ] }
-rip-starttls = { version = "0.1", optional = true, features = ["tokio"] }
+rip-starttls = { version = "0.1", optional = true, default-features = false, git = "https://github.com/felinira/pimalaya-core", branch = "wip/smol-deps" }
 rustls-platform-verifier = { version = "0.6", optional = true }
 thiserror = "2"
-tokio = { version = "1.37", default-features = false, features = [
+tracing = "0.1"
+
+# Executors
+# Tokio
+tokio = { version = "1.37", default-features = false, optional = true, features = [
     "io-util",
     "net",
     "time",
@@ -53,8 +70,16 @@ tokio-rustls = { version = "0.26", optional = true, default-features = false, fe
     "tls12",
     "ring",
 ] }
-tracing = "0.1"
+
+# smol
+smol = { version = "2.0", optional = true }
+async-native-tls = { version = "0.5", optional = true }
+futures-rustls = { version = "0.26", optional = true }
 
 [[example]]
 name = "fetch-tokio-rustls"
-required-features = ["tokio-rustls"]
+required-features = ["tokio", "tokio-rustls"]
+
+[[example]]
+name = "fetch-smol-rustls"
+required-features = ["smol", "futures-rustls"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ imap-next = { version = "0.3", features = [
     "ext_metadata",
 ] }
 rip-starttls = { version = "0.1", optional = true, features = ["tokio"] }
-rustls-platform-verifier = { version = "0.4", optional = true }
+rustls-platform-verifier = { version = "0.6", optional = true }
 thiserror = "2"
 tokio = { version = "1.37", default-features = false, features = [
     "io-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,11 @@ default = []
 
 # TLS providers
 #
-tokio-rustls = ["dep:tokio-rustls", "dep:rip-starttls", "dep:rustls-platform-verifier"]
+tokio-rustls = [
+    "dep:tokio-rustls",
+    "dep:rip-starttls",
+    "dep:rustls-platform-verifier",
+]
 tokio-native-tls = ["dep:tokio-native-tls", "dep:rip-starttls"]
 
 # Vendored (mostly for OpenSSL)
@@ -30,11 +34,27 @@ static_assertions = "1.1"
 tokio = { version = "1.37", features = ["full"] }
 
 [dependencies]
-imap-next = { version = "0.3", features = ["tag_generator", "ext_id", "ext_metadata"] }
+imap-next = { version = "0.3", features = [
+    "tag_generator",
+    "ext_id",
+    "ext_metadata",
+] }
 rip-starttls = { version = "0.1", optional = true, features = ["tokio"] }
 rustls-platform-verifier = { version = "0.4", optional = true }
 thiserror = "2"
-tokio = { version = "1.37", default-features = false, features = ["io-util", "net", "time"] }
+tokio = { version = "1.37", default-features = false, features = [
+    "io-util",
+    "net",
+    "time",
+] }
 tokio-native-tls = { version = "0.3", optional = true }
-tokio-rustls = { version = "0.26", optional = true, default-features = false, features = ["logging", "tls12", "ring"] }
+tokio-rustls = { version = "0.26", optional = true, default-features = false, features = [
+    "logging",
+    "tls12",
+    "ring",
+] }
 tracing = "0.1"
+
+[[example]]
+name = "fetch-tokio-rustls"
+required-features = ["tokio-rustls"]

--- a/examples/fetch-smol-rustls.rs
+++ b/examples/fetch-smol-rustls.rs
@@ -1,0 +1,54 @@
+use imap_client::{
+    client::smol::Client,
+    imap_types::{
+        fetch::{Macro, MacroOrMessageDataItemNames, MessageDataItem},
+        sequence::SequenceSet,
+    },
+};
+
+const USAGE: &str =
+    "USAGE: cargo run --example=fetch-smol-rustls -- <host> <port> <username> <password>";
+
+#[tokio::main]
+async fn main() {
+    let (host, port, username, password) = {
+        let mut args = std::env::args();
+        let _ = args.next();
+
+        (
+            args.next().expect(USAGE),
+            str::parse::<u16>(&args.next().expect(USAGE)).unwrap(),
+            args.next().expect(USAGE),
+            args.next().expect(USAGE),
+        )
+    };
+
+    let mut client = Client::rustls(host, port, false).await.unwrap();
+
+    client.authenticate_plain(username, password).await.unwrap();
+
+    let select_data = client.select("inbox").await.unwrap();
+    println!("{select_data:?}\n");
+
+    let data = client
+        .fetch(
+            SequenceSet::try_from("1:10").unwrap(),
+            MacroOrMessageDataItemNames::Macro(Macro::Full),
+        )
+        .await
+        .unwrap();
+
+    println!("# INBOX\n");
+    for (_, items) in data {
+        let envelope = items
+            .as_ref()
+            .iter()
+            .find(|item| matches!(item, MessageDataItem::Envelope(_)))
+            .unwrap();
+        if let MessageDataItem::Envelope(env) = envelope {
+            if let Some(sub) = &env.subject.0 {
+                println!("* {:?}", std::str::from_utf8(sub.as_ref()).unwrap());
+            }
+        }
+    }
+}

--- a/examples/fetch-tokio-rustls.rs
+++ b/examples/fetch-tokio-rustls.rs
@@ -1,13 +1,12 @@
 use imap_client::{
+    client::tokio::Client,
     imap_types::{
         fetch::{Macro, MacroOrMessageDataItemNames, MessageDataItem},
         sequence::SequenceSet,
     },
-    Client,
 };
 
-const USAGE: &str =
-    "USAGE: cargo run --example=fetch -- <host> <port> <username> <password>";
+const USAGE: &str = "USAGE: cargo run --example=fetch-tokio-rustls --features tokio-rustls -- <host> <port> <username> <password>";
 
 #[tokio::main]
 async fn main() {
@@ -23,7 +22,7 @@ async fn main() {
         )
     };
 
-    let mut client = Client::tls(host, port).await.unwrap();
+    let mut client = Client::rustls(host, port, false).await.unwrap();
 
     client.authenticate_plain(username, password).await.unwrap();
 

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1,3 +1,6 @@
+#[cfg(feature = "smol")]
+pub mod smol;
+#[cfg(feature = "tokio")]
 pub mod tokio;
 
 use std::time::Duration;

--- a/src/client/smol.rs
+++ b/src/client/smol.rs
@@ -1,0 +1,1408 @@
+use std::{
+    cmp::Ordering,
+    collections::HashMap,
+    future::IntoFuture,
+    io,
+    num::NonZeroU32,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use imap_next::{
+    client::{Error as NextError, Event, Options as ClientOptions},
+    imap_types::{
+        command::{Command, CommandBody},
+        core::{AString, IString, Literal, LiteralMode, NString, QuotedChar, Tag, Vec1},
+        error::ValidationError,
+        extensions::{
+            binary::{Literal8, LiteralOrLiteral8},
+            enable::CapabilityEnable,
+            sort::{SortCriterion, SortKey},
+            thread::{Thread, ThreadingAlgorithm},
+        },
+        fetch::{MacroOrMessageDataItemNames, MessageDataItem, MessageDataItemName},
+        flag::{Flag, FlagNameAttribute, StoreType},
+        mailbox::{ListMailbox, Mailbox},
+        response::{Code, Status, Tagged},
+        search::SearchKey,
+        secret::Secret,
+        sequence::SequenceSet,
+        IntoStatic,
+    },
+};
+use rip_starttls::imap::smol::RipStarttls;
+use smol::{
+    future::FutureExt,
+    io::{AsyncRead, AsyncWrite},
+    net::TcpStream,
+};
+use thiserror::Error;
+use tracing::{debug, trace, warn};
+
+use crate::{
+    stream::{self, Stream},
+    tasks::{
+        tasks::{
+            append::{AppendTask, PostAppendCheckTask, PostAppendNoOpTask},
+            appenduid::AppendUidTask,
+            authenticate::AuthenticateTask,
+            capability::CapabilityTask,
+            check::CheckTask,
+            copy::CopyTask,
+            create::CreateTask,
+            delete::DeleteTask,
+            enable::EnableTask,
+            expunge::ExpungeTask,
+            fetch::{FetchFirstTask, FetchTask},
+            id::IdTask,
+            list::ListTask,
+            login::LoginTask,
+            noop::NoOpTask,
+            r#move::MoveTask,
+            search::SearchTask,
+            select::{SelectDataUnvalidated, SelectTask},
+            sort::SortTask,
+            store::StoreTask,
+            thread::ThreadTask,
+            TaskError,
+        },
+        SchedulerError, SchedulerEvent, Task,
+    },
+};
+
+static MAX_SEQUENCE_SIZE: u8 = u8::MAX; // 255
+
+#[derive(Debug, Error)]
+pub enum ClientError {
+    #[error("cannot upgrade client to TLS: client is already in TLS state")]
+    ClientAlreadyTlsError,
+    #[error("cannot do STARTTLS prefix")]
+    DoStarttlsPrefixError(#[from] io::Error),
+    #[error("stream error")]
+    Stream(#[from] stream::Error<SchedulerError>),
+    #[error("validation error")]
+    Validation(#[from] ValidationError),
+    #[error("cannot connect to TCP stream")]
+    ConnectToTcpStreamError(#[source] io::Error),
+    #[error("cannot connect to TLS stream")]
+    ConnectToTlsStreamError(#[source] io::Error),
+
+    #[cfg(feature = "async-native-tls")]
+    #[error("cannot connect to native TLS stream")]
+    ConnectToNativeTlsStreamError(#[source] async_native_tls::Error),
+    #[cfg(feature = "async-native-tls")]
+    #[error("cannot create native TLS connector")]
+    CreateNativeTlsConnectorError(#[source] async_native_tls::Error),
+    #[cfg(feature = "futures-rustls")]
+    #[error("cannot create tokio rustls client config")]
+    CreateRustlsClientConfigError(#[source] futures_rustls::rustls::Error),
+
+    #[error("cannot receive greeting from server")]
+    ReceiveGreeting(#[source] stream::Error<SchedulerError>),
+    #[error("cannot resolve IMAP task")]
+    ResolveTask(#[from] TaskError),
+}
+
+pub enum MaybeTlsStream {
+    Plain(TcpStream),
+    #[cfg(feature = "futures-rustls")]
+    Rustls(futures_rustls::client::TlsStream<TcpStream>),
+    #[cfg(feature = "async-native-tls")]
+    NativeTls(async_native_tls::TlsStream<TcpStream>),
+}
+
+impl AsyncRead for MaybeTlsStream {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut [u8],
+    ) -> Poll<io::Result<usize>> {
+        match self.get_mut() {
+            Self::Plain(s) => Pin::new(s).poll_read(cx, buf),
+            #[cfg(feature = "futures-rustls")]
+            Self::Rustls(s) => Pin::new(s).poll_read(cx, buf),
+            #[cfg(feature = "async-native-tls")]
+            Self::NativeTls(s) => Pin::new(s).poll_read(cx, buf),
+        }
+    }
+}
+
+impl AsyncWrite for MaybeTlsStream {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        match self.get_mut() {
+            Self::Plain(s) => Pin::new(s).poll_write(cx, buf),
+            #[cfg(feature = "futures-rustls")]
+            Self::Rustls(s) => Pin::new(s).poll_write(cx, buf),
+            #[cfg(feature = "async-native-tls")]
+            Self::NativeTls(s) => Pin::new(s).poll_write(cx, buf),
+        }
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
+        match self.get_mut() {
+            Self::Plain(s) => Pin::new(s).poll_flush(cx),
+            #[cfg(feature = "futures-rustls")]
+            Self::Rustls(s) => Pin::new(s).poll_flush(cx),
+            #[cfg(feature = "async-native-tls")]
+            Self::NativeTls(s) => Pin::new(s).poll_flush(cx),
+        }
+    }
+
+    fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
+        match self.get_mut() {
+            Self::Plain(s) => Pin::new(s).poll_close(cx),
+            #[cfg(feature = "futures-rustls")]
+            Self::Rustls(s) => Pin::new(s).poll_close(cx),
+            #[cfg(feature = "async-native-tls")]
+            Self::NativeTls(s) => Pin::new(s).poll_close(cx),
+        }
+    }
+}
+
+pub struct Client {
+    host: String,
+    pub state: super::Client,
+    pub stream: Stream<MaybeTlsStream>,
+}
+
+/// Client constructors.
+///
+/// This section defines 3 public constructors for [`Client`]:
+/// `insecure`, `tls` and `starttls`.
+impl Client {
+    /// Creates an insecure client, using TCP.
+    ///
+    /// This constructor creates a client based on an raw
+    /// [`TcpStream`], receives greeting then saves server
+    /// capabilities.
+    pub async fn insecure(host: impl ToString, port: u16) -> Result<Self, ClientError> {
+        let mut client = Self::tcp(host, port, false).await?;
+
+        if !client.receive_greeting().await? {
+            client.refresh_capabilities().await?;
+        }
+
+        Ok(client)
+    }
+
+    /// Creates a secure client, using SSL/TLS or STARTTLS.
+    ///
+    /// This constructor creates an client based on a secure
+    /// [`TcpStream`] wrapped into a [`TlsStream`], receives greeting
+    /// then saves server capabilities.
+    #[cfg(feature = "futures-rustls")]
+    pub async fn rustls(
+        host: impl ToString,
+        port: u16,
+        starttls: bool,
+    ) -> Result<Self, ClientError> {
+        let tcp = Self::tcp(host, port, starttls).await?;
+        Self::upgrade_rustls(tcp, starttls).await
+    }
+
+    /// Creates a secure client, using SSL/TLS or STARTTLS.
+    ///
+    /// This constructor creates an client based on a secure
+    /// [`TcpStream`] wrapped into a [`TlsStream`], receives greeting
+    /// then saves server capabilities.
+    #[cfg(feature = "async-native-tls")]
+    pub async fn native_tls(
+        host: impl ToString,
+        port: u16,
+        starttls: bool,
+    ) -> Result<Self, ClientError> {
+        let tcp = Self::tcp(host, port, starttls).await?;
+        Self::upgrade_native_tls(tcp, starttls).await
+    }
+
+    /// Creates an insecure client based on a raw [`TcpStream`].
+    ///
+    /// This function is internally used by public constructors
+    /// `insecure`, `tls` and `starttls`.
+    async fn tcp(
+        host: impl ToString,
+        port: u16,
+        discard_greeting: bool,
+    ) -> Result<Self, ClientError> {
+        let host = host.to_string();
+
+        let tcp_stream = TcpStream::connect((host.as_str(), port))
+            .await
+            .map_err(ClientError::ConnectToTcpStreamError)?;
+
+        let stream = Stream::new(MaybeTlsStream::Plain(tcp_stream));
+
+        let mut opts = ClientOptions::default();
+        opts.crlf_relaxed = true;
+        opts.discard_greeting = discard_greeting;
+
+        let state = super::Client::new(opts);
+
+        Ok(Self {
+            host,
+            stream,
+            state,
+        })
+    }
+
+    /// Turns an insecure client into a secure one.
+    ///
+    /// The flow changes depending on the `starttls` parameter:
+    ///
+    /// If `true`: receives greeting, sends STARTTLS command, upgrades
+    /// to TLS then force-refreshes server capabilities.
+    ///
+    /// If `false`: upgrades straight to TLS, receives greeting then
+    /// refreshes server capabilities if needed.
+    #[cfg(feature = "futures-rustls")]
+    async fn upgrade_rustls(mut self, starttls: bool) -> Result<Self, ClientError> {
+        use std::sync::Arc;
+
+        use futures_rustls::{
+            rustls::{pki_types::ServerName, ClientConfig},
+            TlsConnector,
+        };
+        use rustls_platform_verifier::ConfigVerifierExt;
+
+        let MaybeTlsStream::Plain(mut tcp_stream) = self.stream.into_inner() else {
+            return Err(ClientError::ClientAlreadyTlsError);
+        };
+
+        if starttls {
+            tcp_stream = RipStarttls::default()
+                .do_starttls_prefix(tcp_stream)
+                .await
+                .map_err(ClientError::DoStarttlsPrefixError)?;
+        }
+
+        let mut config = ClientConfig::with_platform_verifier()
+            .map_err(ClientError::CreateRustlsClientConfigError)?;
+
+        // See <https://www.iana.org/assignments/tls-extensiontype-values/tls-extensiontype-values.xhtml#alpn-protocol-ids>
+        config.alpn_protocols = vec![b"imap".to_vec()];
+
+        let connector = TlsConnector::from(Arc::new(config));
+        let dnsname = ServerName::try_from(self.host.clone()).unwrap();
+
+        let tls_stream = connector
+            .connect(dnsname, tcp_stream)
+            .await
+            .map_err(ClientError::ConnectToTlsStreamError)?;
+
+        self.stream = Stream::new(MaybeTlsStream::Rustls(tls_stream));
+
+        if starttls || !self.receive_greeting().await? {
+            self.refresh_capabilities().await?;
+        }
+
+        Ok(self)
+    }
+
+    /// Turns an insecure client into a secure one.
+    ///
+    /// The flow changes depending on the `starttls` parameter:
+    ///
+    /// If `true`: receives greeting, sends STARTTLS command, upgrades
+    /// to TLS then force-refreshes server capabilities.
+    ///
+    /// If `false`: upgrades straight to TLS, receives greeting then
+    /// refreshes server capabilities if needed.
+    #[cfg(feature = "async-native-tls")]
+    async fn upgrade_native_tls(mut self, starttls: bool) -> Result<Self, ClientError> {
+        use async_native_tls::TlsConnector;
+
+        let MaybeTlsStream::Plain(mut tcp_stream) = self.stream.into_inner() else {
+            return Err(ClientError::ClientAlreadyTlsError);
+        };
+
+        if starttls {
+            tcp_stream = RipStarttls::default()
+                .do_starttls_prefix(tcp_stream)
+                .await
+                .map_err(ClientError::DoStarttlsPrefixError)?;
+        }
+
+        let connector = TlsConnector::new();
+
+        let tls_stream = connector
+            .connect(&self.host, tcp_stream)
+            .await
+            .map_err(ClientError::ConnectToNativeTlsStreamError)?;
+
+        self.stream = Stream::new(MaybeTlsStream::NativeTls(tls_stream));
+
+        if starttls || !self.receive_greeting().await? {
+            self.refresh_capabilities().await?;
+        }
+
+        Ok(self)
+    }
+
+    /// Receives server greeting.
+    ///
+    /// Returns `true` if server capabilities were found in the
+    /// greeting, otherwise `false`. This boolean is internally used
+    /// to determine if server capabilities need to be explicitly
+    /// requested or not.
+    async fn receive_greeting(&mut self) -> Result<bool, ClientError> {
+        let evt = self
+            .stream
+            .next(&mut self.state.resolver)
+            .await
+            .map_err(ClientError::ReceiveGreeting)?;
+
+        if let SchedulerEvent::GreetingReceived(greeting) = evt {
+            if let Some(Code::Capability(capabilities)) = greeting.code {
+                self.state.capabilities = capabilities;
+                return Ok(true);
+            }
+        }
+
+        Ok(false)
+    }
+}
+
+/// Client low-level API.
+///
+/// This section defines the low-level API of the client, by exposing
+/// convenient wrappers around [`Task`]s. They do not contain any
+/// logic.
+impl Client {
+    /// Resolves the given [`Task`].
+    pub async fn resolve<T: Task>(&mut self, task: T) -> Result<T::Output, ClientError> {
+        Ok(self.stream.next(self.state.resolver.resolve(task)).await?)
+    }
+
+    /// Enables the given capabilities.
+    pub async fn enable(
+        &mut self,
+        capabilities: impl IntoIterator<Item = CapabilityEnable<'_>>,
+    ) -> Result<Option<Vec<CapabilityEnable<'_>>>, ClientError> {
+        if !self.state.ext_enable_supported() {
+            warn!("IMAP ENABLE extension not supported, skipping");
+            return Ok(None);
+        }
+
+        let capabilities: Vec<_> = capabilities
+            .into_iter()
+            .map(IntoStatic::into_static)
+            .collect();
+
+        if capabilities.is_empty() {
+            return Ok(None);
+        }
+
+        let capabilities = Vec1::try_from(capabilities).unwrap();
+
+        Ok(self.resolve(EnableTask::new(capabilities)).await??)
+    }
+
+    /// Creates a new mailbox.
+    pub async fn create(
+        &mut self,
+        mailbox: impl TryInto<Mailbox<'_>, Error = ValidationError>,
+    ) -> Result<(), ClientError> {
+        let mbox = mailbox.try_into()?.into_static();
+        Ok(self.resolve(CreateTask::new(mbox)).await??)
+    }
+
+    /// Lists mailboxes.
+    pub async fn list(
+        &mut self,
+        mailbox: impl TryInto<Mailbox<'_>, Error = ValidationError>,
+        mailbox_wildcard: impl TryInto<ListMailbox<'_>, Error = ValidationError>,
+    ) -> Result<
+        Vec<(
+            Mailbox<'static>,
+            Option<QuotedChar>,
+            Vec<FlagNameAttribute<'static>>,
+        )>,
+        ClientError,
+    > {
+        let mbox = mailbox.try_into()?.into_static();
+        let mbox_wcard = mailbox_wildcard.try_into()?.into_static();
+        Ok(self.resolve(ListTask::new(mbox, mbox_wcard)).await??)
+    }
+
+    /// Selects the given mailbox.
+    pub async fn select(
+        &mut self,
+        mailbox: impl TryInto<Mailbox<'_>, Error = ValidationError>,
+    ) -> Result<SelectDataUnvalidated, ClientError> {
+        let mbox = mailbox.try_into()?.into_static();
+        Ok(self.resolve(SelectTask::new(mbox)).await??)
+    }
+
+    /// Selects the given mailbox in read-only mode.
+    pub async fn examine(
+        &mut self,
+        mailbox: impl TryInto<Mailbox<'_>, Error = ValidationError>,
+    ) -> Result<SelectDataUnvalidated, ClientError> {
+        let mbox = mailbox.try_into()?.into_static();
+        Ok(self.resolve(SelectTask::read_only(mbox)).await??)
+    }
+
+    /// Expunges the selected mailbox.
+    ///
+    /// A mailbox needs to be selected before, otherwise this function
+    /// will fail.
+    pub async fn expunge(&mut self) -> Result<Vec<NonZeroU32>, ClientError> {
+        Ok(self.resolve(ExpungeTask::new()).await??)
+    }
+
+    /// Deletes the given mailbox.
+    pub async fn delete(
+        &mut self,
+        mailbox: impl TryInto<Mailbox<'_>, Error = ValidationError>,
+    ) -> Result<(), ClientError> {
+        let mbox = mailbox.try_into()?.into_static();
+        Ok(self.resolve(DeleteTask::new(mbox)).await??)
+    }
+
+    /// Searches messages matching the given criteria.
+    async fn _search(
+        &mut self,
+        criteria: impl IntoIterator<Item = SearchKey<'_>>,
+        uid: bool,
+    ) -> Result<Vec<NonZeroU32>, ClientError> {
+        let criteria: Vec<_> = criteria.into_iter().map(IntoStatic::into_static).collect();
+
+        let criteria = if criteria.is_empty() {
+            Vec1::from(SearchKey::All)
+        } else {
+            Vec1::try_from(criteria).unwrap()
+        };
+
+        Ok(self
+            .resolve(SearchTask::new(criteria).with_uid(uid))
+            .await??)
+    }
+
+    /// Searches messages matching the given criteria.
+    ///
+    /// This function returns sequence numbers, if you need UID see
+    /// [`Client::uid_search`].
+    pub async fn search(
+        &mut self,
+        criteria: impl IntoIterator<Item = SearchKey<'_>>,
+    ) -> Result<Vec<NonZeroU32>, ClientError> {
+        self._search(criteria, false).await
+    }
+
+    /// Searches messages matching the given criteria.
+    ///
+    /// This function returns UIDs, if you need sequence numbers see
+    /// [`Client::search`].
+    pub async fn uid_search(
+        &mut self,
+        criteria: impl IntoIterator<Item = SearchKey<'_>>,
+    ) -> Result<Vec<NonZeroU32>, ClientError> {
+        self._search(criteria, true).await
+    }
+
+    /// Searches messages matching the given search criteria, sorted
+    /// by the given sort criteria.
+    async fn _sort(
+        &mut self,
+        sort_criteria: impl IntoIterator<Item = SortCriterion>,
+        search_criteria: impl IntoIterator<Item = SearchKey<'_>>,
+        uid: bool,
+    ) -> Result<Vec<NonZeroU32>, ClientError> {
+        let sort: Vec<_> = sort_criteria.into_iter().collect();
+        let sort = if sort.is_empty() {
+            Vec1::from(SortCriterion {
+                reverse: true,
+                key: SortKey::Date,
+            })
+        } else {
+            Vec1::try_from(sort).unwrap()
+        };
+
+        let search: Vec<_> = search_criteria
+            .into_iter()
+            .map(IntoStatic::into_static)
+            .collect();
+        let search = if search.is_empty() {
+            Vec1::from(SearchKey::All)
+        } else {
+            Vec1::try_from(search).unwrap()
+        };
+
+        Ok(self
+            .resolve(SortTask::new(sort, search).with_uid(uid))
+            .await??)
+    }
+
+    /// Searches messages matching the given search criteria, sorted
+    /// by the given sort criteria.
+    ///
+    /// This function returns sequence numbers, if you need UID see
+    /// [`Client::uid_sort`].
+    pub async fn sort(
+        &mut self,
+        sort_criteria: impl IntoIterator<Item = SortCriterion>,
+        search_criteria: impl IntoIterator<Item = SearchKey<'_>>,
+    ) -> Result<Vec<NonZeroU32>, ClientError> {
+        self._sort(sort_criteria, search_criteria, false).await
+    }
+
+    /// Searches messages matching the given search criteria, sorted
+    /// by the given sort criteria.
+    ///
+    /// This function returns UIDs, if you need sequence numbers see
+    /// [`Client::sort`].
+    pub async fn uid_sort(
+        &mut self,
+        sort_criteria: impl IntoIterator<Item = SortCriterion>,
+        search_criteria: impl IntoIterator<Item = SearchKey<'_>>,
+    ) -> Result<Vec<NonZeroU32>, ClientError> {
+        self._sort(sort_criteria, search_criteria, true).await
+    }
+
+    async fn _thread(
+        &mut self,
+        algorithm: ThreadingAlgorithm<'_>,
+        search_criteria: impl IntoIterator<Item = SearchKey<'_>>,
+        uid: bool,
+    ) -> Result<Vec<Thread>, ClientError> {
+        let alg = algorithm.into_static();
+
+        let search: Vec<_> = search_criteria
+            .into_iter()
+            .map(IntoStatic::into_static)
+            .collect();
+        let search = if search.is_empty() {
+            Vec1::from(SearchKey::All)
+        } else {
+            Vec1::try_from(search).unwrap()
+        };
+
+        Ok(self
+            .resolve(ThreadTask::new(alg, search).with_uid(uid))
+            .await??)
+    }
+
+    pub async fn thread(
+        &mut self,
+        algorithm: ThreadingAlgorithm<'_>,
+        search_criteria: impl IntoIterator<Item = SearchKey<'_>>,
+    ) -> Result<Vec<Thread>, ClientError> {
+        self._thread(algorithm, search_criteria, false).await
+    }
+
+    pub async fn uid_thread(
+        &mut self,
+        algorithm: ThreadingAlgorithm<'_>,
+        search_criteria: impl IntoIterator<Item = SearchKey<'_>>,
+    ) -> Result<Vec<Thread>, ClientError> {
+        self._thread(algorithm, search_criteria, true).await
+    }
+
+    async fn _store(
+        &mut self,
+        sequence_set: SequenceSet,
+        kind: StoreType,
+        flags: impl IntoIterator<Item = Flag<'_>>,
+        uid: bool,
+    ) -> Result<HashMap<NonZeroU32, Vec1<MessageDataItem<'static>>>, ClientError> {
+        let flags: Vec<_> = flags.into_iter().map(IntoStatic::into_static).collect();
+
+        Ok(self
+            .resolve(StoreTask::new(sequence_set, kind, flags).with_uid(uid))
+            .await??)
+    }
+
+    pub async fn store(
+        &mut self,
+        sequence_set: SequenceSet,
+        kind: StoreType,
+        flags: impl IntoIterator<Item = Flag<'_>>,
+    ) -> Result<HashMap<NonZeroU32, Vec1<MessageDataItem<'static>>>, ClientError> {
+        self._store(sequence_set, kind, flags, false).await
+    }
+
+    pub async fn uid_store(
+        &mut self,
+        sequence_set: SequenceSet,
+        kind: StoreType,
+        flags: impl IntoIterator<Item = Flag<'_>>,
+    ) -> Result<HashMap<NonZeroU32, Vec1<MessageDataItem<'static>>>, ClientError> {
+        self._store(sequence_set, kind, flags, true).await
+    }
+
+    async fn _silent_store(
+        &mut self,
+        sequence_set: SequenceSet,
+        kind: StoreType,
+        flags: impl IntoIterator<Item = Flag<'_>>,
+        uid: bool,
+    ) -> Result<(), ClientError> {
+        let flags: Vec<_> = flags.into_iter().map(IntoStatic::into_static).collect();
+
+        let task = StoreTask::new(sequence_set, kind, flags)
+            .with_uid(uid)
+            .silent();
+
+        Ok(self.resolve(task).await??)
+    }
+
+    pub async fn silent_store(
+        &mut self,
+        sequence_set: SequenceSet,
+        kind: StoreType,
+        flags: impl IntoIterator<Item = Flag<'_>>,
+    ) -> Result<(), ClientError> {
+        self._silent_store(sequence_set, kind, flags, false).await
+    }
+
+    pub async fn uid_silent_store(
+        &mut self,
+        sequence_set: SequenceSet,
+        kind: StoreType,
+        flags: impl IntoIterator<Item = Flag<'_>>,
+    ) -> Result<(), ClientError> {
+        self._silent_store(sequence_set, kind, flags, true).await
+    }
+
+    pub async fn post_append_noop(&mut self) -> Result<Option<u32>, ClientError> {
+        Ok(self.resolve(PostAppendNoOpTask::new()).await??)
+    }
+
+    pub async fn post_append_check(&mut self) -> Result<Option<u32>, ClientError> {
+        Ok(self.resolve(PostAppendCheckTask::new()).await??)
+    }
+
+    async fn _fetch_first(
+        &mut self,
+        id: NonZeroU32,
+        items: MacroOrMessageDataItemNames<'_>,
+        uid: bool,
+    ) -> Result<Vec1<MessageDataItem<'static>>, ClientError> {
+        let items = items.into_static();
+
+        Ok(self
+            .resolve(FetchFirstTask::new(id, items).with_uid(uid))
+            .await??)
+    }
+
+    pub async fn fetch_first(
+        &mut self,
+        id: NonZeroU32,
+        items: MacroOrMessageDataItemNames<'_>,
+    ) -> Result<Vec1<MessageDataItem<'static>>, ClientError> {
+        self._fetch_first(id, items, false).await
+    }
+
+    pub async fn uid_fetch_first(
+        &mut self,
+        id: NonZeroU32,
+        items: MacroOrMessageDataItemNames<'_>,
+    ) -> Result<Vec1<MessageDataItem<'static>>, ClientError> {
+        self._fetch_first(id, items, true).await
+    }
+
+    async fn _copy(
+        &mut self,
+        sequence_set: SequenceSet,
+        mailbox: impl TryInto<Mailbox<'_>, Error = ValidationError>,
+        uid: bool,
+    ) -> Result<(), ClientError> {
+        let mbox = mailbox.try_into()?.into_static();
+
+        Ok(self
+            .resolve(CopyTask::new(sequence_set, mbox).with_uid(uid))
+            .await??)
+    }
+
+    pub async fn copy(
+        &mut self,
+        sequence_set: SequenceSet,
+        mailbox: impl TryInto<Mailbox<'_>, Error = ValidationError>,
+    ) -> Result<(), ClientError> {
+        self._copy(sequence_set, mailbox, false).await
+    }
+
+    pub async fn uid_copy(
+        &mut self,
+        sequence_set: SequenceSet,
+        mailbox: impl TryInto<Mailbox<'_>, Error = ValidationError>,
+    ) -> Result<(), ClientError> {
+        self._copy(sequence_set, mailbox, true).await
+    }
+
+    async fn _move(
+        &mut self,
+        sequence_set: SequenceSet,
+        mailbox: impl TryInto<Mailbox<'_>, Error = ValidationError>,
+        uid: bool,
+    ) -> Result<(), ClientError> {
+        let mbox = mailbox.try_into()?.into_static();
+
+        Ok(self
+            .resolve(MoveTask::new(sequence_set, mbox).with_uid(uid))
+            .await??)
+    }
+
+    pub async fn r#move(
+        &mut self,
+        sequence_set: SequenceSet,
+        mailbox: impl TryInto<Mailbox<'_>, Error = ValidationError>,
+    ) -> Result<(), ClientError> {
+        self._move(sequence_set, mailbox, false).await
+    }
+
+    pub async fn uid_move(
+        &mut self,
+        sequence_set: SequenceSet,
+        mailbox: impl TryInto<Mailbox<'_>, Error = ValidationError>,
+    ) -> Result<(), ClientError> {
+        self._move(sequence_set, mailbox, true).await
+    }
+
+    /// Executes the `CHECK` command.
+    pub async fn check(&mut self) -> Result<(), ClientError> {
+        Ok(self.resolve(CheckTask::new()).await??)
+    }
+
+    /// Executes the `NOOP` command.
+    pub async fn noop(&mut self) -> Result<(), ClientError> {
+        Ok(self.resolve(NoOpTask::new()).await??)
+    }
+}
+
+/// Client medium-level API.
+///
+/// This section defines the medium-level API of the client (based on
+/// the low-level one), by exposing helpers that update client state
+/// and use a small amount of logic (mostly conditional code depending
+/// on available server capabilities).
+impl Client {
+    /// Fetches server capabilities, then saves them.
+    pub async fn refresh_capabilities(&mut self) -> Result<(), ClientError> {
+        self.state.capabilities = self.resolve(CapabilityTask::new()).await??;
+
+        Ok(())
+    }
+
+    /// Identifies the user using the given username and password.
+    pub async fn login(
+        &mut self,
+        username: impl TryInto<AString<'_>, Error = ValidationError>,
+        password: impl TryInto<AString<'_>, Error = ValidationError>,
+    ) -> Result<(), ClientError> {
+        let username = username.try_into()?.into_static();
+        let password = password.try_into()?.into_static();
+        let login = self.resolve(LoginTask::new(username, Secret::new(password)));
+
+        match login.await?? {
+            Some(capabilities) => {
+                self.state.capabilities = capabilities;
+            }
+            None => {
+                self.refresh_capabilities().await?;
+            }
+        };
+
+        Ok(())
+    }
+
+    /// Authenticates the user using the given [`AuthenticateTask`].
+    ///
+    /// This function also refreshes capabilities (either from the
+    /// task output or from explicit request).
+    async fn authenticate(&mut self, task: AuthenticateTask) -> Result<(), ClientError> {
+        match self.resolve(task).await?? {
+            Some(capabilities) => {
+                self.state.capabilities = capabilities;
+            }
+            None => {
+                self.refresh_capabilities().await?;
+            }
+        };
+
+        Ok(())
+    }
+
+    /// Authenticates the user using the `PLAIN` mechanism.
+    pub async fn authenticate_plain(
+        &mut self,
+        login: impl AsRef<str>,
+        password: impl AsRef<str>,
+    ) -> Result<(), ClientError> {
+        self.authenticate(AuthenticateTask::plain(
+            login.as_ref(),
+            password.as_ref(),
+            self.state.ext_sasl_ir_supported(),
+        ))
+        .await
+    }
+
+    /// Authenticates the user using the `XOAUTH2` mechanism.
+    pub async fn authenticate_xoauth2(
+        &mut self,
+        login: impl AsRef<str>,
+        token: impl AsRef<str>,
+    ) -> Result<(), ClientError> {
+        self.authenticate(AuthenticateTask::xoauth2(
+            login.as_ref(),
+            token.as_ref(),
+            self.state.ext_sasl_ir_supported(),
+        ))
+        .await
+    }
+
+    /// Authenticates the user using the `OAUTHBEARER` mechanism.
+    pub async fn authenticate_oauthbearer(
+        &mut self,
+        user: impl AsRef<str>,
+        host: impl AsRef<str>,
+        port: u16,
+        token: impl AsRef<str>,
+    ) -> Result<(), ClientError> {
+        self.authenticate(AuthenticateTask::oauthbearer(
+            user.as_ref(),
+            host.as_ref(),
+            port,
+            token.as_ref(),
+            self.state.ext_sasl_ir_supported(),
+        ))
+        .await
+    }
+
+    /// Exchanges client/server ids.
+    ///
+    /// If the server does not support the `ID` extension, this
+    /// function has no effect.
+    pub async fn id(
+        &mut self,
+        params: Option<Vec<(IString<'static>, NString<'static>)>>,
+    ) -> Result<Option<Vec<(IString<'static>, NString<'static>)>>, ClientError> {
+        Ok(if self.state.ext_id_supported() {
+            self.resolve(IdTask::new(params)).await??
+        } else {
+            warn!("IMAP ID extension not supported, skipping");
+            None
+        })
+    }
+
+    pub async fn append(
+        &mut self,
+        mailbox: impl TryInto<Mailbox<'_>, Error = ValidationError>,
+        flags: impl IntoIterator<Item = Flag<'_>>,
+        message: impl AsRef<[u8]>,
+    ) -> Result<Option<u32>, ClientError> {
+        let mbox = mailbox.try_into()?.into_static();
+
+        let flags: Vec<_> = flags.into_iter().map(IntoStatic::into_static).collect();
+
+        let msg = to_static_literal(message, self.state.ext_binary_supported())?;
+
+        Ok(self
+            .resolve(AppendTask::new(mbox, msg).with_flags(flags))
+            .await??)
+    }
+
+    pub async fn appenduid(
+        &mut self,
+        mailbox: impl TryInto<Mailbox<'_>, Error = ValidationError>,
+        flags: impl IntoIterator<Item = Flag<'_>>,
+        message: impl AsRef<[u8]>,
+    ) -> Result<Option<(NonZeroU32, NonZeroU32)>, ClientError> {
+        let mbox = mailbox.try_into()?.into_static();
+
+        let flags: Vec<_> = flags.into_iter().map(IntoStatic::into_static).collect();
+
+        let msg = to_static_literal(message, self.state.ext_binary_supported())?;
+
+        Ok(self
+            .resolve(AppendUidTask::new(mbox, msg).with_flags(flags))
+            .await??)
+    }
+}
+
+/// Client high-level API.
+///
+/// This section defines the high-level API of the client (based on
+/// the low and medium ones), by exposing opinionated helpers. They
+/// contain more logic, and make use of fallbacks depending on
+/// available server capabilities.
+impl Client {
+    async fn _fetch(
+        &mut self,
+        sequence_set: SequenceSet,
+        items: MacroOrMessageDataItemNames<'_>,
+        uid: bool,
+    ) -> Result<HashMap<NonZeroU32, Vec1<MessageDataItem<'static>>>, ClientError> {
+        let mut items = match items {
+            MacroOrMessageDataItemNames::Macro(m) => m.expand().into_static(),
+            MacroOrMessageDataItemNames::MessageDataItemNames(items) => items.into_static(),
+        };
+
+        if uid {
+            items.push(MessageDataItemName::Uid);
+        }
+
+        let seq_map = self
+            .resolve(FetchTask::new(sequence_set, items.into()).with_uid(uid))
+            .await??;
+
+        if uid {
+            let mut uid_map = HashMap::new();
+
+            for (seq, items) in seq_map {
+                let uid = items.as_ref().iter().find_map(|item| {
+                    if let MessageDataItem::Uid(uid) = item {
+                        Some(*uid)
+                    } else {
+                        None
+                    }
+                });
+
+                match uid {
+                    Some(uid) => {
+                        uid_map.insert(uid, items);
+                    }
+                    None => {
+                        warn!(?seq, "cannot get message uid, skipping it");
+                    }
+                }
+            }
+
+            Ok(uid_map)
+        } else {
+            Ok(seq_map)
+        }
+    }
+
+    pub async fn fetch(
+        &mut self,
+        sequence_set: SequenceSet,
+        items: MacroOrMessageDataItemNames<'_>,
+    ) -> Result<HashMap<NonZeroU32, Vec1<MessageDataItem<'static>>>, ClientError> {
+        self._fetch(sequence_set, items, false).await
+    }
+
+    pub async fn uid_fetch(
+        &mut self,
+        sequence_set: SequenceSet,
+        items: MacroOrMessageDataItemNames<'_>,
+    ) -> Result<HashMap<NonZeroU32, Vec1<MessageDataItem<'static>>>, ClientError> {
+        self._fetch(sequence_set, items, true).await
+    }
+
+    async fn _sort_or_fallback(
+        &mut self,
+        sort_criteria: impl IntoIterator<Item = SortCriterion> + Clone,
+        search_criteria: impl IntoIterator<Item = SearchKey<'_>>,
+        fetch_items: MacroOrMessageDataItemNames<'_>,
+        uid: bool,
+    ) -> Result<Vec<Vec1<MessageDataItem<'static>>>, ClientError> {
+        let mut fetch_items = match fetch_items {
+            MacroOrMessageDataItemNames::Macro(m) => m.expand().into_static(),
+            MacroOrMessageDataItemNames::MessageDataItemNames(items) => items,
+        };
+
+        if uid && !fetch_items.contains(&MessageDataItemName::Uid) {
+            fetch_items.push(MessageDataItemName::Uid);
+        }
+
+        let mut fetches = HashMap::new();
+
+        if self.state.ext_sort_supported() {
+            let fetch_items = MacroOrMessageDataItemNames::MessageDataItemNames(fetch_items);
+            let ids = self._sort(sort_criteria, search_criteria, uid).await?;
+            let ids_chunks = ids.chunks(MAX_SEQUENCE_SIZE as usize);
+            let ids_chunks_len = ids_chunks.len();
+
+            for (n, ids) in ids_chunks.enumerate() {
+                debug!(?ids, "fetching sort envelopes {}/{ids_chunks_len}", n + 1);
+                let ids = SequenceSet::try_from(ids.to_vec())?;
+                let items = fetch_items.clone();
+                fetches.extend(self._fetch(ids, items, uid).await?);
+            }
+
+            let items = ids.into_iter().flat_map(|id| fetches.remove(&id)).collect();
+
+            Ok(items)
+        } else {
+            warn!("IMAP SORT extension not supported, using fallback");
+
+            let ids = self._search(search_criteria, uid).await?;
+            let ids_chunks = ids.chunks(MAX_SEQUENCE_SIZE as usize);
+            let ids_chunks_len = ids_chunks.len();
+
+            sort_criteria
+                .clone()
+                .into_iter()
+                .filter_map(|criterion| match criterion.key {
+                    SortKey::Arrival => Some(MessageDataItemName::InternalDate),
+                    SortKey::Cc => Some(MessageDataItemName::Envelope),
+                    SortKey::Date => Some(MessageDataItemName::Envelope),
+                    SortKey::From => Some(MessageDataItemName::Envelope),
+                    SortKey::Size => Some(MessageDataItemName::Rfc822Size),
+                    SortKey::Subject => Some(MessageDataItemName::Envelope),
+                    SortKey::To => Some(MessageDataItemName::Envelope),
+                    SortKey::DisplayFrom => None,
+                    SortKey::DisplayTo => None,
+                })
+                .for_each(|item| {
+                    if !fetch_items.contains(&item) {
+                        fetch_items.push(item)
+                    }
+                });
+
+            for (n, ids) in ids_chunks.enumerate() {
+                debug!(?ids, "fetching search envelopes {}/{ids_chunks_len}", n + 1);
+                let ids = SequenceSet::try_from(ids.to_vec())?;
+                let items = fetch_items.clone();
+                fetches.extend(self._fetch(ids, items.into(), uid).await?);
+            }
+
+            let mut fetches: Vec<_> = fetches.into_values().collect();
+
+            fetches.sort_by(|a, b| {
+                for criterion in sort_criteria.clone().into_iter() {
+                    let mut cmp = cmp_fetch_items(&criterion.key, a, b);
+
+                    if criterion.reverse {
+                        cmp = cmp.reverse();
+                    }
+
+                    if cmp.is_ne() {
+                        return cmp;
+                    }
+                }
+
+                cmp_fetch_items(&SortKey::Date, a, b)
+            });
+
+            Ok(fetches)
+        }
+    }
+
+    pub async fn sort_or_fallback(
+        &mut self,
+        sort_criteria: impl IntoIterator<Item = SortCriterion> + Clone,
+        search_criteria: impl IntoIterator<Item = SearchKey<'_>>,
+        fetch_items: MacroOrMessageDataItemNames<'_>,
+    ) -> Result<Vec<Vec1<MessageDataItem<'static>>>, ClientError> {
+        self._sort_or_fallback(sort_criteria, search_criteria, fetch_items, false)
+            .await
+    }
+
+    pub async fn uid_sort_or_fallback(
+        &mut self,
+        sort_criteria: impl IntoIterator<Item = SortCriterion> + Clone,
+        search_criteria: impl IntoIterator<Item = SearchKey<'_>>,
+        fetch_items: MacroOrMessageDataItemNames<'_>,
+    ) -> Result<Vec<Vec1<MessageDataItem<'static>>>, ClientError> {
+        self._sort_or_fallback(sort_criteria, search_criteria, fetch_items, true)
+            .await
+    }
+
+    pub async fn appenduid_or_fallback(
+        &mut self,
+        mailbox: impl TryInto<Mailbox<'_>, Error = ValidationError> + Clone,
+        flags: impl IntoIterator<Item = Flag<'_>>,
+        message: impl AsRef<[u8]>,
+    ) -> Result<Option<NonZeroU32>, ClientError> {
+        if self.state.ext_uidplus_supported() {
+            Ok(self
+                .appenduid(mailbox, flags, message)
+                .await?
+                .map(|(uid, _)| uid))
+        } else {
+            warn!("IMAP UIDPLUS extension not supported, using fallback");
+
+            // If the mailbox is currently selected, the normal new
+            // message actions SHOULD occur.  Specifically, the server
+            // SHOULD notify the client immediately via an untagged
+            // EXISTS response.  If the server does not do so, the
+            // client MAY issue a NOOP command (or failing that, a
+            // CHECK command) after one or more APPEND commands.
+            //
+            // <https://datatracker.ietf.org/doc/html/rfc3501#section-6.3.11>
+            self.select(mailbox.clone()).await?;
+
+            let seq = match self.append(mailbox, flags, message).await? {
+                Some(seq) => seq,
+                None => match self.post_append_noop().await? {
+                    Some(seq) => seq,
+                    None => self
+                        .post_append_check()
+                        .await?
+                        .ok_or(ClientError::ResolveTask(TaskError::MissingData(
+                            "APPENDUID: seq".into(),
+                        )))?,
+                },
+            };
+
+            let uid = self
+                .search(Vec1::from(SearchKey::SequenceSet(seq.try_into().unwrap())))
+                .await?
+                .into_iter()
+                .next();
+
+            Ok(uid)
+        }
+    }
+
+    async fn _move_or_fallback(
+        &mut self,
+        sequence_set: SequenceSet,
+        mailbox: impl TryInto<Mailbox<'_>, Error = ValidationError>,
+        uid: bool,
+    ) -> Result<(), ClientError> {
+        if self.state.ext_move_supported() {
+            self._move(sequence_set, mailbox, uid).await
+        } else {
+            warn!("IMAP MOVE extension not supported, using fallback");
+            self._copy(sequence_set.clone(), mailbox, uid).await?;
+            self._silent_store(sequence_set, StoreType::Add, Some(Flag::Deleted), uid)
+                .await?;
+            self.expunge().await?;
+            Ok(())
+        }
+    }
+
+    pub async fn move_or_fallback(
+        &mut self,
+        sequence_set: SequenceSet,
+        mailbox: impl TryInto<Mailbox<'_>, Error = ValidationError>,
+    ) -> Result<(), ClientError> {
+        self._move_or_fallback(sequence_set, mailbox, false).await
+    }
+
+    pub async fn uid_move_or_fallback(
+        &mut self,
+        sequence_set: SequenceSet,
+        mailbox: impl TryInto<Mailbox<'_>, Error = ValidationError>,
+    ) -> Result<(), ClientError> {
+        self._move_or_fallback(sequence_set, mailbox, true).await
+    }
+
+    pub fn enqueue_idle(&mut self) -> Tag<'static> {
+        let tag = self.state.resolver.scheduler.tag_generator.generate();
+
+        self.state
+            .resolver
+            .scheduler
+            .client_next
+            .enqueue_command(Command {
+                tag: tag.clone(),
+                body: CommandBody::Idle,
+            });
+
+        tag.into_static()
+    }
+
+    #[tracing::instrument(name = "idle", skip_all)]
+    pub async fn idle(&mut self, tag: Tag<'static>) -> Result<(), stream::Error<NextError>> {
+        debug!("starting the main loop");
+
+        loop {
+            let progress = self
+                .stream
+                .next(&mut self.state.resolver.scheduler.client_next);
+            match timeout(self.state.idle_timeout, progress).await.ok() {
+                None => {
+                    debug!("timed out, sending done command…");
+                    self.state.resolver.scheduler.client_next.set_idle_done();
+                }
+                Some(Err(err)) => {
+                    break Err(err);
+                }
+                Some(Ok(Event::IdleCommandSent { .. })) => {
+                    debug!("command sent");
+                }
+                Some(Ok(Event::IdleAccepted { .. })) => {
+                    debug!("command accepted, entering idle mode");
+                }
+                Some(Ok(Event::IdleRejected { status, .. })) => {
+                    warn!("command rejected, aborting: {status:?}");
+                    break Ok(());
+                }
+                Some(Ok(Event::IdleDoneSent { .. })) => {
+                    debug!("done command sent");
+                }
+                Some(Ok(Event::DataReceived { data })) => {
+                    debug!("received data, sending done command…");
+                    trace!("{data:#?}");
+                    self.state.resolver.scheduler.client_next.set_idle_done();
+                }
+                Some(Ok(Event::StatusReceived {
+                    status:
+                        Status::Tagged(Tagged {
+                            tag: ref got_tag, ..
+                        }),
+                })) if *got_tag == tag => {
+                    debug!("received tagged response, exiting");
+                    break Ok(());
+                }
+                Some(event) => {
+                    debug!("received unknown event, ignoring: {event:?}");
+                }
+            }
+        }
+    }
+
+    #[tracing::instrument(name = "idle/done", skip_all)]
+    pub async fn idle_done(&mut self, tag: Tag<'static>) -> Result<(), stream::Error<NextError>> {
+        self.state.resolver.scheduler.client_next.set_idle_done();
+
+        loop {
+            let progress = self
+                .stream
+                .next(&mut self.state.resolver.scheduler.client_next)
+                .await?;
+
+            match progress {
+                Event::IdleDoneSent { .. } => {
+                    debug!("done command sent");
+                }
+                Event::StatusReceived {
+                    status:
+                        Status::Tagged(Tagged {
+                            tag: ref got_tag, ..
+                        }),
+                } if *got_tag == tag => {
+                    debug!("received tagged response, exiting");
+                    break Ok(());
+                }
+                event => {
+                    debug!("received unknown event, ignoring: {event:?}");
+                }
+            }
+        }
+    }
+}
+
+pub(crate) fn cmp_fetch_items(
+    criterion: &SortKey,
+    a: &Vec1<MessageDataItem>,
+    b: &Vec1<MessageDataItem>,
+) -> Ordering {
+    use MessageDataItem::*;
+
+    match &criterion {
+        SortKey::Arrival => {
+            let a = a.as_ref().iter().find_map(|a| {
+                if let InternalDate(dt) = a {
+                    Some(dt.as_ref())
+                } else {
+                    None
+                }
+            });
+
+            let b = b.as_ref().iter().find_map(|b| {
+                if let InternalDate(dt) = b {
+                    Some(dt.as_ref())
+                } else {
+                    None
+                }
+            });
+
+            a.cmp(&b)
+        }
+        SortKey::Date => {
+            let a = a.as_ref().iter().find_map(|a| {
+                if let Envelope(envelope) = a {
+                    envelope.date.0.as_ref().map(AsRef::as_ref)
+                } else {
+                    None
+                }
+            });
+
+            let b = b.as_ref().iter().find_map(|b| {
+                if let Envelope(envelope) = b {
+                    envelope.date.0.as_ref().map(AsRef::as_ref)
+                } else {
+                    None
+                }
+            });
+
+            a.cmp(&b)
+        }
+        SortKey::Size => {
+            let a = a.as_ref().iter().find_map(|a| {
+                if let Rfc822Size(size) = a {
+                    Some(size)
+                } else {
+                    None
+                }
+            });
+
+            let b = b.as_ref().iter().find_map(|b| {
+                if let Rfc822Size(size) = b {
+                    Some(size)
+                } else {
+                    None
+                }
+            });
+
+            a.cmp(&b)
+        }
+        SortKey::Subject => {
+            let a = a.as_ref().iter().find_map(|a| {
+                if let Envelope(envelope) = a {
+                    envelope.subject.0.as_ref().map(AsRef::as_ref)
+                } else {
+                    None
+                }
+            });
+
+            let b = b.as_ref().iter().find_map(|b| {
+                if let Envelope(envelope) = b {
+                    envelope.subject.0.as_ref().map(AsRef::as_ref)
+                } else {
+                    None
+                }
+            });
+
+            a.cmp(&b)
+        }
+        // FIXME: Address missing Ord derive in imap-types
+        SortKey::Cc | SortKey::From | SortKey::To | SortKey::DisplayFrom | SortKey::DisplayTo => {
+            Ordering::Equal
+        }
+    }
+}
+
+pub(crate) fn to_static_literal(
+    message: impl AsRef<[u8]>,
+    ext_binary_supported: bool,
+) -> Result<LiteralOrLiteral8<'static>, ValidationError> {
+    let message = if ext_binary_supported {
+        LiteralOrLiteral8::Literal8(Literal8 {
+            data: message.as_ref().into(),
+            mode: LiteralMode::Sync,
+        })
+    } else {
+        warn!("IMAP BINARY extension not supported, using fallback");
+        Literal::validate(message.as_ref())?;
+        LiteralOrLiteral8::Literal(Literal::unvalidated(message.as_ref()))
+    };
+
+    Ok(message.into_static())
+}
+
+pub(crate) async fn timeout<R>(
+    timeout: std::time::Duration,
+    fut: impl IntoFuture<Output = R>,
+) -> std::result::Result<R, TimedOut> {
+    let ok_res = async { Ok(fut.await) };
+    let err_res = async {
+        smol::Timer::after(timeout).await;
+        Err(TimedOut())
+    };
+
+    ok_res.or(err_res).await
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+#[error("Timed Out")]
+pub struct TimedOut();

--- a/src/client/tokio.rs
+++ b/src/client/tokio.rs
@@ -93,6 +93,9 @@ pub enum ClientError {
     #[cfg(feature = "tokio-native-tls")]
     #[error("cannot create native TLS connector")]
     CreateNativeTlsConnectorError(#[source] tokio_native_tls::native_tls::Error),
+    #[cfg(feature = "tokio-rustls")]
+    #[error("cannot create tokio rustls client config")]
+    CreateRustlsClientConfigError(#[source] tokio_rustls::rustls::Error),
 
     #[error("cannot receive greeting from server")]
     ReceiveGreeting(#[source] stream::Error<SchedulerError>),
@@ -276,7 +279,8 @@ impl Client {
                 .map_err(ClientError::DoStarttlsPrefixError)?;
         }
 
-        let mut config = ClientConfig::with_platform_verifier();
+        let mut config = ClientConfig::with_platform_verifier()
+            .map_err(ClientError::CreateRustlsClientConfigError)?;
 
         // See <https://www.iana.org/assignments/tls-extensiontype-values/tls-extensiontype-values.xhtml#alpn-protocol-ids>
         config.alpn_protocols = vec![b"imap".to_vec()];

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -1,7 +1,9 @@
-use imap_next::{Interrupt, Io, State};
+#[cfg(feature = "smol")]
+mod smol;
+#[cfg(feature = "tokio")]
+mod tokio;
+
 use thiserror::Error;
-use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
-use tracing::trace;
 
 pub struct Stream<S> {
     stream: S,
@@ -18,48 +20,6 @@ impl<S> Stream<S> {
 
     pub fn into_inner(self) -> S {
         self.stream
-    }
-}
-
-impl<S: AsyncRead + AsyncWrite + Unpin> Stream<S> {
-    pub async fn next<F: State>(&mut self, mut state: F) -> Result<F::Event, Error<F::Error>> {
-        let event = loop {
-            // Progress the client/server
-            let result = state.next();
-
-            // Return events immediately without doing IO
-            let interrupt = match result {
-                Err(interrupt) => interrupt,
-                Ok(event) => break event,
-            };
-
-            // Return errors immediately without doing IO
-            let io = match interrupt {
-                Interrupt::Io(io) => io,
-                Interrupt::Error(err) => return Err(Error::State(err)),
-            };
-
-            // Handle the output bytes from the client/server
-            match io {
-                Io::Output(ref bytes) => match self.stream.write(bytes).await? {
-                    0 => return Err(Error::Closed),
-                    n => trace!("wrote {n}/{} bytes", bytes.len()),
-                },
-                Io::NeedMoreInput => {
-                    trace!("more input needed");
-                }
-            }
-
-            match self.stream.read(&mut self.buf).await? {
-                0 => return Err(Error::Closed),
-                n => {
-                    trace!("read {n}/{} bytes", self.buf.len());
-                    state.enqueue_input(&self.buf[..n]);
-                }
-            }
-        };
-
-        Ok(event)
     }
 }
 

--- a/src/stream/smol.rs
+++ b/src/stream/smol.rs
@@ -1,0 +1,47 @@
+use super::{Error, Stream};
+
+use imap_next::{Interrupt, Io, State};
+use smol::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+use tracing::trace;
+
+impl<S: AsyncRead + AsyncWrite + Unpin> Stream<S> {
+    pub async fn next<F: State>(&mut self, mut state: F) -> Result<F::Event, Error<F::Error>> {
+        let event = loop {
+            // Progress the client/server
+            let result = state.next();
+
+            // Return events immediately without doing IO
+            let interrupt = match result {
+                Err(interrupt) => interrupt,
+                Ok(event) => break event,
+            };
+
+            // Return errors immediately without doing IO
+            let io = match interrupt {
+                Interrupt::Io(io) => io,
+                Interrupt::Error(err) => return Err(Error::State(err)),
+            };
+
+            // Handle the output bytes from the client/server
+            match io {
+                Io::Output(ref bytes) => match self.stream.write(bytes).await? {
+                    0 => return Err(Error::Closed),
+                    n => trace!("wrote {n}/{} bytes", bytes.len()),
+                },
+                Io::NeedMoreInput => {
+                    trace!("more input needed");
+                }
+            }
+
+            match self.stream.read(&mut self.buf).await? {
+                0 => return Err(Error::Closed),
+                n => {
+                    trace!("read {n}/{} bytes", self.buf.len());
+                    state.enqueue_input(&self.buf[..n]);
+                }
+            }
+        };
+
+        Ok(event)
+    }
+}

--- a/src/stream/tokio.rs
+++ b/src/stream/tokio.rs
@@ -1,0 +1,47 @@
+use super::{Error, Stream};
+
+use imap_next::{Interrupt, Io, State};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+use tracing::trace;
+
+impl<S: AsyncRead + AsyncWrite + Unpin> Stream<S> {
+    pub async fn next<F: State>(&mut self, mut state: F) -> Result<F::Event, Error<F::Error>> {
+        let event = loop {
+            // Progress the client/server
+            let result = state.next();
+
+            // Return events immediately without doing IO
+            let interrupt = match result {
+                Err(interrupt) => interrupt,
+                Ok(event) => break event,
+            };
+
+            // Return errors immediately without doing IO
+            let io = match interrupt {
+                Interrupt::Io(io) => io,
+                Interrupt::Error(err) => return Err(Error::State(err)),
+            };
+
+            // Handle the output bytes from the client/server
+            match io {
+                Io::Output(ref bytes) => match self.stream.write(bytes).await? {
+                    0 => return Err(Error::Closed),
+                    n => trace!("wrote {n}/{} bytes", bytes.len()),
+                },
+                Io::NeedMoreInput => {
+                    trace!("more input needed");
+                }
+            }
+
+            match self.stream.read(&mut self.buf).await? {
+                0 => return Err(Error::Closed),
+                n => {
+                    trace!("read {n}/{} bytes", self.buf.len());
+                    state.enqueue_input(&self.buf[..n]);
+                }
+            }
+        };
+
+        Ok(event)
+    }
+}


### PR DESCRIPTION
Based on #19 and #20, please take a look at them first, they are much simpler to review :)

Also based on https://github.com/pimalaya/core/pull/37

Adds support for the smol runtime as an option besides the tokio runtime.

There is still a lot of duplication going on here. I am quite sure it can be significantly reduced by completely pulling `Client` out of the tokio module (and renaming it, or the other `Client`) and just having a few `#[cfg(feature = "tokio")]` in some places. Alternatively we could have traits that implement the extra functionality on top of `Client`.