### PR TITLE
feat: add support for CONDSTORE for quick flag / mailbox resync (RFC 7162)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ repository = "https://github.com/pimalaya/imap-client/"
 
 [features]
 default = []
+condstore = ["imap-next/ext_condstore_qresync"]
 
 [dev-dependencies]
 async-std = { version = "1.13", features = ["attributes"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ repository = "https://github.com/pimalaya/imap-client/"
 
 [features]
 default = []
-condstore = ["imap-next/ext_condstore_qresync"]
 
 [dev-dependencies]
 async-std = { version = "1.13", features = ["attributes"] }

--- a/examples/condstore.rs
+++ b/examples/condstore.rs
@@ -9,7 +9,7 @@ use imap_next::imap_types::{
 use std::num::NonZero;
 
 const USAGE: &str =
-    "USAGE: cargo run --features condstore --example=condstore -- <host> <port> <username> <password> [cached_modseq]";
+    "USAGE: cargo run --example=condstore -- <host> <port> <username> <password> [cached_modseq]";
 
 #[tokio::main]
 async fn main() {
@@ -30,97 +30,88 @@ async fn main() {
 
     client.authenticate_plain(username, password).await.unwrap();
 
-    #[cfg(feature = "condstore")]
-    {
-        if client.state.ext_condstore_supported() {
-            let enabled = client.enable_condstore_if_supported().await.unwrap();
-            println!("CONDSTORE enabled via ENABLE command: {}", enabled);
-        } else {
-            println!("CONDSTORE is not supported by the server");
-        }
-
-        // Select mailbox with CONDSTORE enabled
-        let select_data = client.select("inbox").await.unwrap();
-        println!("\nSelect data: {select_data:?}");
-
-        if let Some(modseq) = select_data.highest_modseq {
-            println!("\nCONDSTORE is active (HIGHESTMODSEQ: {})", modseq);
-
-            // Determine test MODSEQ: use cached value if provided, otherwise subtract 200 from HIGHESTMODSEQ
-            let test_modseq = if let Some(cached) = cached_modseq {
-                println!("Using cached MODSEQ: {}", cached);
-                std::num::NonZeroU64::new(cached).unwrap()
-            } else {
-                let offset = 200;
-                let calculated = modseq.get().saturating_sub(offset);
-                println!(
-                    "No cached MODSEQ provided, using HIGHESTMODSEQ - {} = {}",
-                    offset, calculated
-                );
-                std::num::NonZeroU64::new(calculated).unwrap()
-            };
-
-            println!("\n--- Testing FETCH CHANGEDSINCE {} ---", test_modseq);
-            let modifiers = vec![FetchModifier::ChangedSince(
-                NonZero::new(test_modseq.get()).unwrap(),
-            )];
-            let changed_messages = client
-                .fetch_with_modifiers(
-                    SequenceSet::try_from("1:*").unwrap(),
-                    MacroOrMessageDataItemNames::Macro(Macro::Fast),
-                    modifiers,
-                )
-                .await
-                .unwrap();
-
-            println!(
-                "FETCH CHANGEDSINCE found {} changed messages",
-                changed_messages.len()
-            );
-
-            // Test SEARCH MODSEQ
-            println!("\n--- Testing SEARCH MODSEQ {} ---", test_modseq);
-
-            let search_results = client
-                .search(Vec1::from(SearchKey::ModSequence {
-                    entry: None,
-                    modseq: test_modseq.get(),
-                }))
-                .await
-                .unwrap();
-
-            println!("SEARCH MODSEQ found {} messages", search_results.len());
-
-            // Test UID FETCH VANISHED (requires QRESYNC)
-            if client.state.capabilities_iter().any(|c| matches!(c, imap_client::imap_types::response::Capability::QResync)) {
-                println!("\n--- Testing UID FETCH VANISHED (QRESYNC) ---");
-
-                let vanished_task = FetchTask::new(
-                    SequenceSet::try_from("1:*").unwrap(),
-                    MacroOrMessageDataItemNames::Macro(Macro::Fast),
-                )
-                .with_changed_since(test_modseq)
-                .with_vanished();
-
-                match client.resolve(vanished_task).await {
-                    Ok(Ok(messages)) => {
-                        println!("UID FETCH VANISHED found {} messages", messages.len());
-                        println!("Note: VANISHED responses show deleted UIDs");
-                    }
-                    Ok(Err(e)) => println!("UID FETCH VANISHED error: {:?}", e),
-                    Err(e) => println!("UID FETCH VANISHED error: {:?}", e),
-                }
-            } else {
-                println!("\n✗ QRESYNC not supported (UID FETCH VANISHED unavailable)");
-            }
-        } else {
-            println!("\nCONDSTORE is not active (no HIGHESTMODSEQ returned)");
-        }
+    if client.state.ext_condstore_supported() {
+        let enabled = client.enable_condstore_if_supported().await.unwrap();
+        println!("CONDSTORE enabled via ENABLE command: {}", enabled);
+    } else {
+        println!("CONDSTORE is not supported by the server");
     }
 
-    #[cfg(not(feature = "condstore"))]
-    {
-        println!("This example requires the condstore feature");
-        println!("Run with: cargo run --features condstore --example=condstore");
+    // Select mailbox with CONDSTORE enabled
+    let select_data = client.select("inbox").await.unwrap();
+    println!("\nSelect data: {select_data:?}");
+
+    if let Some(modseq) = select_data.highest_modseq {
+        println!("\nCONDSTORE is active (HIGHESTMODSEQ: {})", modseq);
+
+        // Determine test MODSEQ: use cached value if provided, otherwise subtract 200 from HIGHESTMODSEQ
+        let test_modseq = if let Some(cached) = cached_modseq {
+            println!("Using cached MODSEQ: {}", cached);
+            std::num::NonZeroU64::new(cached).unwrap()
+        } else {
+            let offset = 200;
+            let calculated = modseq.get().saturating_sub(offset);
+            println!(
+                "No cached MODSEQ provided, using HIGHESTMODSEQ - {} = {}",
+                offset, calculated
+            );
+            std::num::NonZeroU64::new(calculated).unwrap()
+        };
+
+        println!("\n--- Testing FETCH CHANGEDSINCE {} ---", test_modseq);
+        let modifiers = vec![FetchModifier::ChangedSince(
+            NonZero::new(test_modseq.get()).unwrap(),
+        )];
+        let changed_messages = client
+            .fetch_with_modifiers(
+                SequenceSet::try_from("1:*").unwrap(),
+                MacroOrMessageDataItemNames::Macro(Macro::Fast),
+                modifiers,
+            )
+            .await
+            .unwrap();
+
+        println!(
+            "FETCH CHANGEDSINCE found {} changed messages",
+            changed_messages.len()
+        );
+
+        // Test SEARCH MODSEQ
+        println!("\n--- Testing SEARCH MODSEQ {} ---", test_modseq);
+
+        let search_results = client
+            .search(Vec1::from(SearchKey::ModSequence {
+                entry: None,
+                modseq: test_modseq.get(),
+            }))
+            .await
+            .unwrap();
+
+        println!("SEARCH MODSEQ found {} messages", search_results.len());
+
+        // Test UID FETCH VANISHED (requires QRESYNC)
+        if client.state.capabilities_iter().any(|c| matches!(c, imap_client::imap_types::response::Capability::QResync)) {
+            println!("\n--- Testing UID FETCH VANISHED (QRESYNC) ---");
+
+            let vanished_task = FetchTask::new(
+                SequenceSet::try_from("1:*").unwrap(),
+                MacroOrMessageDataItemNames::Macro(Macro::Fast),
+            )
+            .with_changed_since(test_modseq)
+            .with_vanished();
+
+            match client.resolve(vanished_task).await {
+                Ok(Ok(messages)) => {
+                    println!("UID FETCH VANISHED found {} messages", messages.len());
+                    println!("Note: VANISHED responses show deleted UIDs");
+                }
+                Ok(Err(e)) => println!("UID FETCH VANISHED error: {:?}", e),
+                Err(e) => println!("UID FETCH VANISHED error: {:?}", e),
+            }
+        } else {
+            println!("\n✗ QRESYNC not supported (UID FETCH VANISHED unavailable)");
+        }
+    } else {
+        println!("\nCONDSTORE is not active (no HIGHESTMODSEQ returned)");
     }
 }

--- a/examples/condstore.rs
+++ b/examples/condstore.rs
@@ -1,4 +1,4 @@
-use imap_client::client::tokio::Client;
+use imap_client::{client::tokio::Client, tasks::tasks::fetch::FetchTask};
 use imap_next::imap_types::{
     command::FetchModifier,
     core::Vec1,
@@ -90,6 +90,29 @@ async fn main() {
                 .unwrap();
 
             println!("SEARCH MODSEQ found {} messages", search_results.len());
+
+            // Test UID FETCH VANISHED (requires QRESYNC)
+            if client.state.capabilities_iter().any(|c| matches!(c, imap_client::imap_types::response::Capability::QResync)) {
+                println!("\n--- Testing UID FETCH VANISHED (QRESYNC) ---");
+
+                let vanished_task = FetchTask::new(
+                    SequenceSet::try_from("1:*").unwrap(),
+                    MacroOrMessageDataItemNames::Macro(Macro::Fast),
+                )
+                .with_changed_since(test_modseq)
+                .with_vanished();
+
+                match client.resolve(vanished_task).await {
+                    Ok(Ok(messages)) => {
+                        println!("UID FETCH VANISHED found {} messages", messages.len());
+                        println!("Note: VANISHED responses show deleted UIDs");
+                    }
+                    Ok(Err(e)) => println!("UID FETCH VANISHED error: {:?}", e),
+                    Err(e) => println!("UID FETCH VANISHED error: {:?}", e),
+                }
+            } else {
+                println!("\n✗ QRESYNC not supported (UID FETCH VANISHED unavailable)");
+            }
         } else {
             println!("\nCONDSTORE is not active (no HIGHESTMODSEQ returned)");
         }

--- a/examples/condstore.rs
+++ b/examples/condstore.rs
@@ -1,0 +1,103 @@
+use imap_client::client::tokio::Client;
+use imap_next::imap_types::{
+    command::FetchModifier,
+    core::Vec1,
+    fetch::{Macro, MacroOrMessageDataItemNames},
+    search::SearchKey,
+    sequence::SequenceSet,
+};
+use std::num::NonZero;
+
+const USAGE: &str =
+    "USAGE: cargo run --features condstore --example=condstore -- <host> <port> <username> <password> [cached_modseq]";
+
+#[tokio::main]
+async fn main() {
+    let (host, port, username, password, cached_modseq) = {
+        let mut args = std::env::args();
+        let _ = args.next();
+
+        let host = args.next().expect(USAGE);
+        let port = str::parse::<u16>(&args.next().expect(USAGE)).unwrap();
+        let username = args.next().expect(USAGE);
+        let password = args.next().expect(USAGE);
+        let cached_modseq = args.next().and_then(|s| s.parse::<u64>().ok());
+
+        (host, port, username, password, cached_modseq)
+    };
+
+    let mut client = Client::rustls(host, port, false, None).await.unwrap();
+
+    client.authenticate_plain(username, password).await.unwrap();
+
+    #[cfg(feature = "condstore")]
+    {
+        if client.state.ext_condstore_supported() {
+            let enabled = client.enable_condstore_if_supported().await.unwrap();
+            println!("CONDSTORE enabled via ENABLE command: {}", enabled);
+        } else {
+            println!("CONDSTORE is not supported by the server");
+        }
+
+        // Select mailbox with CONDSTORE enabled
+        let select_data = client.select("inbox").await.unwrap();
+        println!("\nSelect data: {select_data:?}");
+
+        if let Some(modseq) = select_data.highest_modseq {
+            println!("\nCONDSTORE is active (HIGHESTMODSEQ: {})", modseq);
+
+            // Determine test MODSEQ: use cached value if provided, otherwise subtract 200 from HIGHESTMODSEQ
+            let test_modseq = if let Some(cached) = cached_modseq {
+                println!("Using cached MODSEQ: {}", cached);
+                std::num::NonZeroU64::new(cached).unwrap()
+            } else {
+                let offset = 200;
+                let calculated = modseq.get().saturating_sub(offset);
+                println!(
+                    "No cached MODSEQ provided, using HIGHESTMODSEQ - {} = {}",
+                    offset, calculated
+                );
+                std::num::NonZeroU64::new(calculated).unwrap()
+            };
+
+            println!("\n--- Testing FETCH CHANGEDSINCE {} ---", test_modseq);
+            let modifiers = vec![FetchModifier::ChangedSince(
+                NonZero::new(test_modseq.get()).unwrap(),
+            )];
+            let changed_messages = client
+                .fetch_with_modifiers(
+                    SequenceSet::try_from("1:*").unwrap(),
+                    MacroOrMessageDataItemNames::Macro(Macro::Fast),
+                    modifiers,
+                )
+                .await
+                .unwrap();
+
+            println!(
+                "FETCH CHANGEDSINCE found {} changed messages",
+                changed_messages.len()
+            );
+
+            // Test SEARCH MODSEQ
+            println!("\n--- Testing SEARCH MODSEQ {} ---", test_modseq);
+
+            let search_results = client
+                .search(Vec1::from(SearchKey::ModSequence {
+                    entry: None,
+                    modseq: test_modseq.get(),
+                }))
+                .await
+                .unwrap();
+
+            println!("SEARCH MODSEQ found {} messages", search_results.len());
+        } else {
+            println!("\nCONDSTORE is not active (no HIGHESTMODSEQ returned)");
+        }
+    }
+
+    #[cfg(not(feature = "condstore"))]
+    {
+        println!("This example requires the condstore feature");
+        println!("Run with: cargo run --features condstore --example=condstore");
+    }
+}

--- a/examples/fetch.rs
+++ b/examples/fetch.rs
@@ -6,8 +6,7 @@ use imap_client::{
     Client,
 };
 
-const USAGE: &str =
-    "USAGE: cargo run --example=fetch -- <host> <port> <username> <password>";
+const USAGE: &str = "USAGE: cargo run --example=fetch -- <host> <port> <username> <password>";
 
 #[tokio::main]
 async fn main() {

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -14,7 +14,6 @@ pub struct Client {
     resolver: Resolver,
     capabilities: Vec1<Capability<'static>>,
     idle_timeout: Duration,
-    #[cfg(feature = "condstore")]
     condstore_enabled: bool,
 }
 
@@ -27,7 +26,6 @@ impl Client {
             resolver,
             capabilities: Vec1::from(Capability::Imap4Rev1),
             idle_timeout: Duration::from_secs(5 * 60), // 5 min
-            #[cfg(feature = "condstore")]
             condstore_enabled: false,
         }
     }
@@ -169,14 +167,12 @@ impl Client {
 
     /// Returns `true` if the `CONDSTORE` extension is supported by the
     /// server.
-    #[cfg(feature = "condstore")]
     pub fn ext_condstore_supported(&self) -> bool {
         self.capabilities_iter()
             .any(|c| matches!(c, Capability::CondStore))
     }
 
     /// Returns `true` if the `CONDSTORE` extension is enabled.
-    #[cfg(feature = "condstore")]
     pub fn condstore_enabled(&self) -> bool {
         self.condstore_enabled
     }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -14,6 +14,8 @@ pub struct Client {
     resolver: Resolver,
     capabilities: Vec1<Capability<'static>>,
     idle_timeout: Duration,
+    #[cfg(feature = "condstore")]
+    condstore_enabled: bool,
 }
 
 impl Client {
@@ -25,6 +27,8 @@ impl Client {
             resolver,
             capabilities: Vec1::from(Capability::Imap4Rev1),
             idle_timeout: Duration::from_secs(5 * 60), // 5 min
+            #[cfg(feature = "condstore")]
+            condstore_enabled: false,
         }
     }
 
@@ -161,5 +165,19 @@ impl Client {
     pub fn ext_move_supported(&self) -> bool {
         self.capabilities_iter()
             .any(|c| matches!(c, Capability::Move))
+    }
+
+    /// Returns `true` if the `CONDSTORE` extension is supported by the
+    /// server.
+    #[cfg(feature = "condstore")]
+    pub fn ext_condstore_supported(&self) -> bool {
+        self.capabilities_iter()
+            .any(|c| matches!(c, Capability::CondStore))
+    }
+
+    /// Returns `true` if the `CONDSTORE` extension is enabled.
+    #[cfg(feature = "condstore")]
+    pub fn condstore_enabled(&self) -> bool {
+        self.condstore_enabled
     }
 }

--- a/src/client/tokio.rs
+++ b/src/client/tokio.rs
@@ -353,7 +353,6 @@ impl Client {
     }
 
     /// Enables the CONDSTORE extension if supported by the server.
-    #[cfg(feature = "condstore")]
     pub async fn enable_condstore_if_supported(&mut self) -> Result<bool, ClientError> {
         if !self.state.ext_condstore_supported() || !self.state.ext_enable_supported() {
             return Ok(false);
@@ -401,9 +400,7 @@ impl Client {
         mailbox: impl TryInto<Mailbox<'_>, Error = ValidationError>,
     ) -> Result<SelectDataUnvalidated, ClientError> {
         let mbox = mailbox.try_into()?.into_static();
-        let task = SelectTask::new(mbox);
-        #[cfg(feature = "condstore")]
-        let task = task.with_condstore(self.state.condstore_enabled());
+        let task = SelectTask::new(mbox).with_condstore(self.state.condstore_enabled());
         Ok(self.resolve(task).await??)
     }
 
@@ -413,9 +410,7 @@ impl Client {
         mailbox: impl TryInto<Mailbox<'_>, Error = ValidationError>,
     ) -> Result<SelectDataUnvalidated, ClientError> {
         let mbox = mailbox.try_into()?.into_static();
-        let task = SelectTask::read_only(mbox);
-        #[cfg(feature = "condstore")]
-        let task = task.with_condstore(self.state.condstore_enabled());
+        let task = SelectTask::read_only(mbox).with_condstore(self.state.condstore_enabled());
         Ok(self.resolve(task).await??)
     }
 

--- a/src/client/tokio.rs
+++ b/src/client/tokio.rs
@@ -12,7 +12,7 @@ use std::{
 use imap_next::{
     client::{Error as NextError, Event, Options as ClientOptions},
     imap_types::{
-        command::{Command, CommandBody},
+        command::{Command, CommandBody, FetchModifier},
         core::{AString, IString, Literal, LiteralMode, NString, QuotedChar, Tag, Vec1},
         error::ValidationError,
         extensions::{
@@ -352,6 +352,22 @@ impl Client {
         Ok(self.resolve(EnableTask::new(capabilities)).await??)
     }
 
+    /// Enables the CONDSTORE extension if supported by the server.
+    #[cfg(feature = "condstore")]
+    pub async fn enable_condstore_if_supported(&mut self) -> Result<bool, ClientError> {
+        if !self.state.ext_condstore_supported() || !self.state.ext_enable_supported() {
+            return Ok(false);
+        }
+
+        let enable = self.enable(vec![CapabilityEnable::CondStore]);
+
+        let enabled = (enable.await?)
+            .map(|capabilities| capabilities.contains(&CapabilityEnable::CondStore))
+            .unwrap_or(false);
+        self.state.condstore_enabled = enabled;
+        Ok(enabled)
+    }
+
     /// Creates a new mailbox.
     pub async fn create(
         &mut self,
@@ -385,7 +401,10 @@ impl Client {
         mailbox: impl TryInto<Mailbox<'_>, Error = ValidationError>,
     ) -> Result<SelectDataUnvalidated, ClientError> {
         let mbox = mailbox.try_into()?.into_static();
-        Ok(self.resolve(SelectTask::new(mbox)).await??)
+        let task = SelectTask::new(mbox);
+        #[cfg(feature = "condstore")]
+        let task = task.with_condstore(self.state.condstore_enabled());
+        Ok(self.resolve(task).await??)
     }
 
     /// Selects the given mailbox in read-only mode.
@@ -394,7 +413,10 @@ impl Client {
         mailbox: impl TryInto<Mailbox<'_>, Error = ValidationError>,
     ) -> Result<SelectDataUnvalidated, ClientError> {
         let mbox = mailbox.try_into()?.into_static();
-        Ok(self.resolve(SelectTask::read_only(mbox)).await??)
+        let task = SelectTask::read_only(mbox);
+        #[cfg(feature = "condstore")]
+        let task = task.with_condstore(self.state.condstore_enabled());
+        Ok(self.resolve(task).await??)
     }
 
     /// Expunges the selected mailbox.
@@ -887,6 +909,7 @@ impl Client {
         sequence_set: SequenceSet,
         items: MacroOrMessageDataItemNames<'_>,
         uid: bool,
+        modifiers: Option<Vec<FetchModifier>>,
     ) -> Result<HashMap<NonZeroU32, Vec1<MessageDataItem<'static>>>, ClientError> {
         let mut items = match items {
             MacroOrMessageDataItemNames::Macro(m) => m.expand().into_static(),
@@ -897,9 +920,10 @@ impl Client {
             items.push(MessageDataItemName::Uid);
         }
 
-        let seq_map = self
-            .resolve(FetchTask::new(sequence_set, items.into()).with_uid(uid))
-            .await??;
+        let mut task = FetchTask::new(sequence_set, items.into()).with_uid(uid);
+        modifiers.map(|m| task.set_modifiers(m));
+
+        let seq_map = self.resolve(task).await??;
 
         if uid {
             let mut uid_map = HashMap::new();
@@ -934,7 +958,17 @@ impl Client {
         sequence_set: SequenceSet,
         items: MacroOrMessageDataItemNames<'_>,
     ) -> Result<HashMap<NonZeroU32, Vec1<MessageDataItem<'static>>>, ClientError> {
-        self._fetch(sequence_set, items, false).await
+        self._fetch(sequence_set, items, false, None).await
+    }
+
+    pub async fn fetch_with_modifiers(
+        &mut self,
+        sequence_set: SequenceSet,
+        items: MacroOrMessageDataItemNames<'_>,
+        modifiers: Vec<FetchModifier>,
+    ) -> Result<HashMap<NonZeroU32, Vec1<MessageDataItem<'static>>>, ClientError> {
+        self._fetch(sequence_set, items, false, Some(modifiers))
+            .await
     }
 
     pub async fn uid_fetch(
@@ -942,7 +976,17 @@ impl Client {
         sequence_set: SequenceSet,
         items: MacroOrMessageDataItemNames<'_>,
     ) -> Result<HashMap<NonZeroU32, Vec1<MessageDataItem<'static>>>, ClientError> {
-        self._fetch(sequence_set, items, true).await
+        self._fetch(sequence_set, items, true, None).await
+    }
+
+    pub async fn uid_fetch_with_modifiers(
+        &mut self,
+        sequence_set: SequenceSet,
+        items: MacroOrMessageDataItemNames<'_>,
+        modifiers: Vec<FetchModifier>,
+    ) -> Result<HashMap<NonZeroU32, Vec1<MessageDataItem<'static>>>, ClientError> {
+        self._fetch(sequence_set, items, true, Some(modifiers))
+            .await
     }
 
     async fn _sort_or_fallback(
@@ -973,7 +1017,7 @@ impl Client {
                 debug!(?ids, "fetching sort envelopes {}/{ids_chunks_len}", n + 1);
                 let ids = SequenceSet::try_from(ids.to_vec())?;
                 let items = fetch_items.clone();
-                fetches.extend(self._fetch(ids, items, uid).await?);
+                fetches.extend(self._fetch(ids, items, uid, None).await?);
             }
 
             let items = ids.into_iter().flat_map(|id| fetches.remove(&id)).collect();
@@ -1010,7 +1054,7 @@ impl Client {
                 debug!(?ids, "fetching search envelopes {}/{ids_chunks_len}", n + 1);
                 let ids = SequenceSet::try_from(ids.to_vec())?;
                 let items = fetch_items.clone();
-                fetches.extend(self._fetch(ids, items.into(), uid).await?);
+                fetches.extend(self._fetch(ids, items.into(), uid, None).await?);
             }
 
             let mut fetches: Vec<_> = fetches.into_values().collect();

--- a/src/tasks/tasks/fetch.rs
+++ b/src/tasks/tasks/fetch.rs
@@ -55,8 +55,15 @@ impl FetchTask {
         self
     }
 
+    #[cfg(feature = "condstore")]
     pub fn with_changed_since(mut self, modseq: std::num::NonZeroU64) -> Self {
-        self.modifiers.push(FetchModifier::ChangedSince(modseq));
+        self.modifiers.push(imap_next::imap_types::command::FetchModifier::ChangedSince(modseq));
+        self
+    }
+
+    #[cfg(feature = "condstore")]
+    pub fn with_vanished(mut self) -> Self {
+        self.modifiers.push(imap_next::imap_types::command::FetchModifier::Vanished);
         self
     }
 }

--- a/src/tasks/tasks/fetch.rs
+++ b/src/tasks/tasks/fetch.rs
@@ -55,13 +55,11 @@ impl FetchTask {
         self
     }
 
-    #[cfg(feature = "condstore")]
     pub fn with_changed_since(mut self, modseq: std::num::NonZeroU64) -> Self {
         self.modifiers.push(imap_next::imap_types::command::FetchModifier::ChangedSince(modseq));
         self
     }
 
-    #[cfg(feature = "condstore")]
     pub fn with_vanished(mut self) -> Self {
         self.modifiers.push(imap_next::imap_types::command::FetchModifier::Vanished);
         self

--- a/src/tasks/tasks/fetch.rs
+++ b/src/tasks/tasks/fetch.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use imap_next::imap_types::{
-    command::CommandBody,
+    command::{CommandBody, FetchModifier},
     core::Vec1,
     fetch::{MacroOrMessageDataItemNames, MessageDataItem},
     response::{Data, StatusBody, StatusKind},
@@ -22,6 +22,7 @@ pub struct FetchTask {
     sequence_set: SequenceSet,
     macro_or_item_names: MacroOrMessageDataItemNames<'static>,
     uid: bool,
+    modifiers: Vec<FetchModifier>,
     output: HashMap<NonZeroU32, HashSet<MessageDataItem<'static>>>,
 }
 
@@ -31,6 +32,7 @@ impl FetchTask {
             sequence_set,
             macro_or_item_names: items,
             uid: true,
+            modifiers: Default::default(),
             output: Default::default(),
         }
     }
@@ -43,6 +45,20 @@ impl FetchTask {
         self.set_uid(uid);
         self
     }
+
+    pub fn set_modifiers(&mut self, modifiers: Vec<FetchModifier>) {
+        self.modifiers = modifiers;
+    }
+
+    pub fn with_modifiers(mut self, modifiers: Vec<FetchModifier>) -> Self {
+        self.modifiers = modifiers;
+        self
+    }
+
+    pub fn with_changed_since(mut self, modseq: std::num::NonZeroU64) -> Self {
+        self.modifiers.push(FetchModifier::ChangedSince(modseq));
+        self
+    }
 }
 
 impl Task for FetchTask {
@@ -50,7 +66,7 @@ impl Task for FetchTask {
 
     fn command_body(&self) -> CommandBody<'static> {
         CommandBody::Fetch {
-            modifiers: Default::default(),
+            modifiers: self.modifiers.clone(),
             sequence_set: self.sequence_set.clone(),
             macro_or_item_names: self.macro_or_item_names.clone(),
             uid: self.uid,

--- a/src/tasks/tasks/select.rs
+++ b/src/tasks/tasks/select.rs
@@ -25,7 +25,6 @@ pub struct SelectDataUnvalidated {
     pub uid_validity: Option<NonZeroU32>,
 
     // optional CONDSTORE response
-    #[cfg(feature = "condstore")]
     pub highest_modseq: Option<std::num::NonZeroU64>,
 }
 
@@ -67,7 +66,6 @@ impl SelectDataUnvalidated {
 pub struct SelectTask {
     mailbox: Mailbox<'static>,
     read_only: bool,
-    #[cfg(feature = "condstore")]
     condstore_enabled: bool,
     output: SelectDataUnvalidated,
 }
@@ -77,7 +75,6 @@ impl SelectTask {
         Self {
             mailbox,
             read_only: false,
-            #[cfg(feature = "condstore")]
             condstore_enabled: false,
             output: Default::default(),
         }
@@ -87,13 +84,11 @@ impl SelectTask {
         Self {
             mailbox,
             read_only: true,
-            #[cfg(feature = "condstore")]
             condstore_enabled: false,
             output: Default::default(),
         }
     }
 
-    #[cfg(feature = "condstore")]
     pub fn with_condstore(mut self, enabled: bool) -> Self {
         self.condstore_enabled = enabled;
         self
@@ -106,16 +101,12 @@ impl Task for SelectTask {
     fn command_body(&self) -> CommandBody<'static> {
         let mailbox = self.mailbox.clone();
 
-        #[cfg(feature = "condstore")]
         let parameters = if self.condstore_enabled {
             use imap_next::imap_types::command::SelectParameter;
             vec![SelectParameter::CondStore]
         } else {
-            Vec::new()
+            Default::default()
         };
-
-        #[cfg(not(feature = "condstore"))]
-        let parameters = Vec::new();
 
         if self.read_only {
             CommandBody::Examine {
@@ -170,7 +161,6 @@ impl Task for SelectTask {
                     self.output.uid_validity = Some(uid);
                     None
                 }
-                #[cfg(feature = "condstore")]
                 Some(Code::HighestModSeq(modseq)) => {
                     self.output.highest_modseq = Some(modseq);
                     None

--- a/src/tasks/tasks/select.rs
+++ b/src/tasks/tasks/select.rs
@@ -23,6 +23,10 @@ pub struct SelectDataUnvalidated {
     pub permanent_flags: Option<Vec<FlagPerm<'static>>>,
     pub uid_next: Option<NonZeroU32>,
     pub uid_validity: Option<NonZeroU32>,
+
+    // optional CONDSTORE response
+    #[cfg(feature = "condstore")]
+    pub highest_modseq: Option<std::num::NonZeroU64>,
 }
 
 impl SelectDataUnvalidated {
@@ -63,6 +67,8 @@ impl SelectDataUnvalidated {
 pub struct SelectTask {
     mailbox: Mailbox<'static>,
     read_only: bool,
+    #[cfg(feature = "condstore")]
+    condstore_enabled: bool,
     output: SelectDataUnvalidated,
 }
 
@@ -71,6 +77,8 @@ impl SelectTask {
         Self {
             mailbox,
             read_only: false,
+            #[cfg(feature = "condstore")]
+            condstore_enabled: false,
             output: Default::default(),
         }
     }
@@ -79,8 +87,16 @@ impl SelectTask {
         Self {
             mailbox,
             read_only: true,
+            #[cfg(feature = "condstore")]
+            condstore_enabled: false,
             output: Default::default(),
         }
+    }
+
+    #[cfg(feature = "condstore")]
+    pub fn with_condstore(mut self, enabled: bool) -> Self {
+        self.condstore_enabled = enabled;
+        self
     }
 }
 
@@ -90,15 +106,26 @@ impl Task for SelectTask {
     fn command_body(&self) -> CommandBody<'static> {
         let mailbox = self.mailbox.clone();
 
+        #[cfg(feature = "condstore")]
+        let parameters = if self.condstore_enabled {
+            use imap_next::imap_types::command::SelectParameter;
+            vec![SelectParameter::CondStore]
+        } else {
+            Vec::new()
+        };
+
+        #[cfg(not(feature = "condstore"))]
+        let parameters = Vec::new();
+
         if self.read_only {
             CommandBody::Examine {
                 mailbox,
-                parameters: Default::default(),
+                parameters,
             }
         } else {
             CommandBody::Select {
                 mailbox,
-                parameters: Default::default(),
+                parameters,
             }
         }
     }
@@ -141,6 +168,11 @@ impl Task for SelectTask {
                 }
                 Some(Code::UidValidity(uid)) => {
                     self.output.uid_validity = Some(uid);
+                    None
+                }
+                #[cfg(feature = "condstore")]
+                Some(Code::HighestModSeq(modseq)) => {
+                    self.output.highest_modseq = Some(modseq);
                     None
                 }
                 _ => Some(status_body),


### PR DESCRIPTION
Hello,

This PR support for `CONDSTORE` for quick flag / mailbox resync from [RFC 7162](https://www.rfc-editor.org/rfc/rfc7162.html).

I recently heard about Himalaya and I am a big of the project since I like tools that allow me to automate my workflow from the command line. Great work to the team and everyone involved!

I've tried experimenting with [my own proof-of-concept email CLI](https://github.com/kylefeng28/anmari) recently (the tags were heavily inspired by notmuch and the interface was inspired by himalaya) just to get familiar with the IMAP protocol and how `CONDSTORE` works, and I believe I've come up with a working implementation for pimalaya/imap-client in Rust.

Paraphrasing from [RFC 4549](https://www.rfc-editor.org/rfc/rfc4549#section-6.1), Section 6.1 for example of how CONDSTORE / HIGHESTMODSEQ works for an IMAP client to synchronize with the server without needing to check every single message when the server supports the `CONDSTORE` extension:
1. Client checks the server mailbox's `HIGHESTMODSEQ` (which is returned during a `SELECT`) and compares it against the previous `HIGHESTMODSEQ` during the last sync
2. Client discovers new messages from the server by doing `FETCH <lastseenuid+1>:*` (where `<lastseenuid>` is the latest UID of the latest message fetched from the last sync)
3. Client discovers flag changes to old messages
  1. If the client's cached `HIGHESTMODSEQ` is the same as the server's `HIGHESTMODSEQ`, this step is skipped
  2. Otherwise, the client calls `FETCH 1:* (FLAGS) (CHANGEDSINCE <cached-value>)` or `SEARCH MODSEQ <cached-value>`
4. Client discovers expunged messages using `UID SEARCH 1:<lastseenuid>`. All messages not returned in this command are expunged.
  1. Note: [RFC 7162](https://www.rfc-editor.org/rfc/rfc7162.html) also talks about `QRESYNC`, which allows the client to skip this step by calling `UID FETCH <uidseq> (FLAGS) (CHANGEDSINCE <cached-value> VANISHED)`, which will return a list of the UIDs that were expunged from the server. This is not implemented in this PR.

**Features**
- Add support for detecting and enabling `CONDSTORE` capability
  - `client/tokio.rs`: `enable_condstore_if_supported()` 
- Retrieve `HIGHESTMODSEQ` from SELECT response, can be used with `FETCH CHANGEDSINCE` modifier or `SEARCH MODSEQ`

I included an example at `examples/condstore.rs` which should demonstrate how to use imap_types `FetchModifier::ChangedSince` and `SearchKey::ModSequence` with the imap_client fetch()/search() commands.
