### PR TITLE
fix: use UTF-8 for search to support non-ASCII characters (i.e. CJK)

### DIFF
--- a/src/tasks/tasks/search.rs
+++ b/src/tasks/tasks/search.rs
@@ -2,7 +2,7 @@ use std::num::NonZeroU32;
 
 use imap_next::imap_types::{
     command::CommandBody,
-    core::Vec1,
+    core::{Charset, Vec1},
     response::{Data, StatusBody, StatusKind},
     search::SearchKey,
 };
@@ -50,7 +50,7 @@ impl Task for SearchTask {
 
     fn command_body(&self) -> CommandBody<'static> {
         CommandBody::Search {
-            charset: None,
+            charset: Some(Charset::try_from("UTF-8").unwrap()),
             criteria: self.criteria.clone(),
             uid: self.uid,
         }


### PR DESCRIPTION
Fixes pimalaya/himalaya#635. Thanks @ncukondo for raising the issue!

> The search should return envelopes matching the non-ASCII subject query. Per RFC 2060 / RFC 3501, the IMAP SEARCH command should include CHARSET UTF-8 when the search string contains non-ASCII characters:

**Before / incorrect behavior**
```
$ himalaya envelope list "subject お知らせ"

Error:
   0: cannot search IMAP envelope UIDs
   1: cannot resolve IMAP task
   2: unexpected BAD response: Could not parse command

```

**After / fixed behavior**
```
$ himalaya envelope list "subject お知らせ"
(Produces expected results)

```

<img width="1346" height="726" alt="Screenshot 2026-02-24 at 00 52 33" src="https://github.com/user-attachments/assets/f8c88a2a-73e6-4070-baea-a89ccd31bcf2" />
